### PR TITLE
Handle 404s and allow logging for uncaught exceptions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,5 @@ env:
   matrix:
     - TEST_STEP=lint
     - TEST_STEP=test
-    - TEST_STEP=coveralls
 notifications:
   email: false

--- a/example/server.js
+++ b/example/server.js
@@ -19,7 +19,7 @@ fs.readdirSync(path.join(__dirname, "/resources")).filter(function(filename) {
   return path.join(__dirname, "/resources/", filename);
 }).forEach(require);
 
-jsonApi.onError(function(request, error) {
+jsonApi.onUncaughtException(function(request, error) {
   var errorDetails = error.stack.split("\n");
   console.error(JSON.stringify({
     request: request,

--- a/example/server.js
+++ b/example/server.js
@@ -19,6 +19,15 @@ fs.readdirSync(path.join(__dirname, "/resources")).filter(function(filename) {
   return path.join(__dirname, "/resources/", filename);
 }).forEach(require);
 
+jsonApi.onError(function(request, error) {
+  var errorDetails = error.stack.split("\n");
+  console.error(JSON.stringify({
+    request: request,
+    error: errorDetails.shift(),
+    stack: errorDetails
+  }));
+});
+
 jsonApi.start();
 server.start = jsonApi.start;
 server.close = jsonApi.close;

--- a/lib/jsonApi.js
+++ b/lib/jsonApi.js
@@ -79,7 +79,7 @@ jsonApi.define = function(resourceConfig) {
   })));
 };
 
-jsonApi.onError = function(errHandler) {
+jsonApi.onUncaughtException = function(errHandler) {
   jsonApi._errHandler = errHandler;
 };
 

--- a/lib/jsonApi.js
+++ b/lib/jsonApi.js
@@ -79,6 +79,10 @@ jsonApi.define = function(resourceConfig) {
   })));
 };
 
+jsonApi.onError = function(errHandler) {
+  jsonApi._errHandler = errHandler;
+};
+
 jsonApi.start = function() {
   routes.register();
   router.listen(jsonApi._apiConfig.port);

--- a/lib/router.js
+++ b/lib/router.js
@@ -45,6 +45,22 @@ router.bindToServer = function(config, callback) {
   });
 };
 
+router.bind404 = function(callback) {
+  app.use(function(req, res) {
+    var request = router._getParams(req);
+    router._setResponseHeaders(request, res);
+    return callback(request, res);
+  });
+};
+
+router.bindErrorHandler = function(callback) {
+  app.use(function(error, req, res, next) {
+    var request = router._getParams(req);
+    router._setResponseHeaders(request, res);
+    return callback(request, res, error, next);
+  });
+};
+
 router._getParams = function(req) {
   var urlParts = req.url.split("?");
   return {

--- a/lib/router.js
+++ b/lib/router.js
@@ -35,7 +35,7 @@ router.using = function(jsonApi) {
   router._jsonApi = jsonApi;
 };
 
-router.bindToServer = function(config, callback) {
+router.bindRoute = function(config, callback) {
   app[config.verb](router._jsonApi._apiConfig.base + config.path, function(req, res) {
     var request = router._getParams(req);
     var resourceConfig = router._jsonApi._resources[request.params.type];

--- a/lib/routes/_foreignKeySearch.js
+++ b/lib/routes/_foreignKeySearch.js
@@ -9,7 +9,7 @@ var responseHelper = require("../responseHelper.js");
 
 
 foreignKeySearchRoute.register = function() {
-  router.bindToServer({
+  router.bindRoute({
     verb: "get",
     path: ":type/relationships/?"
   }, function(request, resourceConfig, res) {

--- a/lib/routes/addRelation.js
+++ b/lib/routes/addRelation.js
@@ -9,7 +9,7 @@ var responseHelper = require("../responseHelper.js");
 
 
 addRelationRoute.register = function() {
-  router.bindToServer({
+  router.bindRoute({
     verb: "post",
     path: ":type/:id/relationships/:relation"
   }, function(request, resourceConfig, res) {

--- a/lib/routes/create.js
+++ b/lib/routes/create.js
@@ -11,7 +11,7 @@ var responseHelper = require("../responseHelper.js");
 
 
 createRoute.register = function() {
-  router.bindToServer({
+  router.bindRoute({
     verb: "post",
     path: ":type"
   }, function(request, resourceConfig, res) {

--- a/lib/routes/delete.js
+++ b/lib/routes/delete.js
@@ -8,7 +8,7 @@ var responseHelper = require("../responseHelper.js");
 
 
 deleteRoute.register = function() {
-  router.bindToServer({
+  router.bindRoute({
     verb: "delete",
     path: ":type/:id"
   }, function(request, resourceConfig, res) {

--- a/lib/routes/find.js
+++ b/lib/routes/find.js
@@ -9,7 +9,7 @@ var responseHelper = require("../responseHelper.js");
 
 
 findRoute.register = function() {
-  router.bindToServer({
+  router.bindRoute({
     verb: "get",
     path: ":type/:id"
   }, function(request, resourceConfig, res) {

--- a/lib/routes/helper.js
+++ b/lib/routes/helper.js
@@ -7,15 +7,6 @@ var router = require("../router.js");
 
 
 helper.validate = function(someObject, someDefinition, callback) {
-  if (!someObject || !someDefinition) {
-    return callback({
-      status: "500",
-      code: "EUNKNOWN",
-      title: "An unknown error has occured. Sorry?",
-      detail: "Missing parameters for handler validation"
-    });
-  }
-
   Joi.validate(someObject, someDefinition, function (err) {
     if (err) {
       return callback({

--- a/lib/routes/related.js
+++ b/lib/routes/related.js
@@ -9,7 +9,7 @@ var responseHelper = require("../responseHelper.js");
 
 
 relatedRoute.register = function() {
-  router.bindToServer({
+  router.bindRoute({
     verb: "get",
     path: ":type/:id/:relation"
   }, function(request, resourceConfig, res) {

--- a/lib/routes/relationships.js
+++ b/lib/routes/relationships.js
@@ -9,7 +9,7 @@ var responseHelper = require("../responseHelper.js");
 
 
 relationshipsRoute.register = function() {
-  router.bindToServer({
+  router.bindRoute({
     verb: "get",
     path: ":type/:id/relationships/:relation"
   }, function(request, resourceConfig, res) {

--- a/lib/routes/removeRelation.js
+++ b/lib/routes/removeRelation.js
@@ -9,7 +9,7 @@ var responseHelper = require("../responseHelper.js");
 
 
 removeRelationRoute.register = function() {
-  router.bindToServer({
+  router.bindRoute({
     verb: "delete",
     path: ":type/:id/relationships/:relation"
   }, function(request, resourceConfig, res) {

--- a/lib/routes/search.js
+++ b/lib/routes/search.js
@@ -9,7 +9,7 @@ var responseHelper = require("../responseHelper.js");
 
 
 searchRoute.register = function() {
-  router.bindToServer({
+  router.bindRoute({
     verb: "get",
     path: ":type"
   }, function(request, resourceConfig, res) {

--- a/lib/routes/update.js
+++ b/lib/routes/update.js
@@ -10,7 +10,7 @@ var responseHelper = require("../responseHelper.js");
 
 
 updateRoute.register = function() {
-  router.bindToServer({
+  router.bindRoute({
     verb: "patch",
     path: ":type/:id"
   }, function(request, resourceConfig, res) {

--- a/lib/routes/updateRelation.js
+++ b/lib/routes/updateRelation.js
@@ -10,7 +10,7 @@ var responseHelper = require("../responseHelper.js");
 
 
 updateRelationRoute.register = function() {
-  router.bindToServer({
+  router.bindRoute({
     verb: "patch",
     path: ":type/:id/relationships/:relation"
   }, function(request, resourceConfig, res) {

--- a/lib/routes/z404.js
+++ b/lib/routes/z404.js
@@ -1,0 +1,17 @@
+"use strict";
+var fourOhFour = module.exports = { };
+
+var helper = require("./helper.js");
+var router = require("../router.js");
+
+
+fourOhFour.register = function() {
+  router.bind404(function(request, res) {
+    return helper.handleError(request, res, {
+      status: "404",
+      code: "EINVALID",
+      title: "Invalid Route",
+      detail: "This is not the API you are looking for?"
+    });
+  });
+};

--- a/lib/routes/zerrorHandler.js
+++ b/lib/routes/zerrorHandler.js
@@ -1,6 +1,7 @@
 "use strict";
 var errorHandler = module.exports = { };
 
+var jsonApi = require("../jsonApi.js");
 var helper = require("./helper.js");
 var router = require("../router.js");
 
@@ -8,12 +9,9 @@ var router = require("../router.js");
 errorHandler.register = function() {
   router.bindErrorHandler(function(request, res, error) {
 
-    var errorDetails = error.stack.split("\n");
-    console.error(JSON.stringify({
-      request: request,
-      error: errorDetails.shift(),
-      stack: errorDetails
-    }));
+    if (jsonApi._errHandler) {
+      jsonApi._errHandler(request, error);
+    }
 
     return helper.handleError(request, res, {
       status: "500",

--- a/lib/routes/zerrorHandler.js
+++ b/lib/routes/zerrorHandler.js
@@ -1,0 +1,25 @@
+"use strict";
+var errorHandler = module.exports = { };
+
+var helper = require("./helper.js");
+var router = require("../router.js");
+
+
+errorHandler.register = function() {
+  router.bindErrorHandler(function(request, res, error) {
+
+    var errorDetails = error.stack.split("\n");
+    console.log(JSON.stringify({
+      request: request,
+      error: errorDetails.shift(),
+      stack: errorDetails
+    }));
+
+    return helper.handleError(request, res, {
+      status: "500",
+      code: "EUNKNOWN",
+      title: "An unknown error has occured. Sorry?",
+      detail: "??"
+    });
+  });
+};

--- a/lib/routes/zerrorHandler.js
+++ b/lib/routes/zerrorHandler.js
@@ -9,7 +9,7 @@ errorHandler.register = function() {
   router.bindErrorHandler(function(request, res, error) {
 
     var errorDetails = error.stack.split("\n");
-    console.log(JSON.stringify({
+    console.error(JSON.stringify({
       request: request,
       error: errorDetails.shift(),
       stack: errorDetails

--- a/test/404.js
+++ b/test/404.js
@@ -1,0 +1,45 @@
+"use strict";
+var request = require("request");
+var assert = require("assert");
+var helpers = require("./helpers.js");
+var jsonApiTestServer = require("../example/server.js");
+
+
+describe("Testing jsonapi-server", function() {
+  describe("404 pages", function() {
+    it("errors with invalid type #1", function(done) {
+      var data = {
+        method: "get",
+        url: "http://localhost:16006/res"
+      };
+      request(data, function(err, res, json) {
+        assert.equal(err, null);
+        json = helpers.validateError(json);
+        assert.equal(res.statusCode, "404", "Expecting 404");
+
+        done();
+      });
+    });
+
+    it("errors with invalid type #2", function(done) {
+      var data = {
+        method: "get",
+        url: "http://localhost:16006/rest/a/b/c/d/e"
+      };
+      request(data, function(err, res, json) {
+        assert.equal(err, null);
+        json = helpers.validateError(json);
+        assert.equal(res.statusCode, "404", "Expecting 404");
+
+        done();
+      });
+    });
+  });
+
+  before(function() {
+    jsonApiTestServer.start();
+  });
+  after(function() {
+    jsonApiTestServer.close();
+  });
+});


### PR DESCRIPTION
1. Catch all invalid paths and respond with a sensible 404 jsonapi error.
2. Allow users of jsonapi-server to implement their own error logging for uncaught exceptions. An example use case might be:

```javascript
var jsonApi = require("jsonapi-server");

jsonApi.setConfig({
  base: "rest",
  port: 16006,
  meta: {
    copyright: "Blah"
  }
});

jsonApi.onUncaughtException(function(request, error) {
  // Log the error to file, or stdout, or external service?
});

jsonApi.start();
```