### PR TITLE
Enable meta blocks for resources and relationships

### DIFF
--- a/example/resources/articles.js
+++ b/example/resources/articles.js
@@ -35,14 +35,21 @@ jsonApi.define({
       type: "articles",
       title: "NodeJS Best Practices",
       content: "na",
-      author: { type: "people", id: "cc5cca2e-0dd8-4b95-8cfc-a11230e73116" },
+      author: {
+        type: "people",
+        id: "cc5cca2e-0dd8-4b95-8cfc-a11230e73116",
+        meta: { updated: "2010-11-06" }
+      },
       tags: [
         { type: "tags", id: "7541a4de-4986-4597-81b9-cf31b6762486" }
       ],
       photos: [ ],
       comments: [
         { type: "comments", id: "3f1a89c2-eb85-4799-a048-6735db24b7eb" }
-      ]
+      ],
+      meta: {
+        updated: "2011-05-10"
+      }
     },
     {
       id: "1be0913c-3c25-4261-98f1-e41174025ed5",

--- a/example/resources/comments.js
+++ b/example/resources/comments.js
@@ -33,7 +33,7 @@ jsonApi.define({
       type: "comments",
       body: "I like XML better",
       timestamp: "2017-06-20",
-      author: { type: "people", id: "32fb0105-acaa-4adb-9ec4-8b49633695e1" }
+      author: { type: "people", id: "32fb0105-acaa-4adb-9ec4-8b49633695e1", meta: { created: "2010-01-01" } }
     }
   ]
 });

--- a/lib/jsonApi.js
+++ b/lib/jsonApi.js
@@ -69,7 +69,8 @@ jsonApi.define = function(resourceConfig) {
       .example("1234"),
     type: ourJoi.Joi.string().required().valid(resourceConfig.resource)
       .description("Always \"" + resourceConfig.resource + "\"")
-      .example(resourceConfig.resource)
+      .example(resourceConfig.resource),
+    meta: ourJoi.Joi.any()
   }, resourceConfig.attributes);
 
   resourceConfig.onCreate = _.pick.apply(_, [].concat(resourceConfig.attributes, Object.keys(resourceConfig.attributes).filter(function(i) {

--- a/lib/jsonApi.js
+++ b/lib/jsonApi.js
@@ -70,7 +70,7 @@ jsonApi.define = function(resourceConfig) {
     type: ourJoi.Joi.string().required().valid(resourceConfig.resource)
       .description("Always \"" + resourceConfig.resource + "\"")
       .example(resourceConfig.resource),
-    meta: ourJoi.Joi.any()
+    meta: ourJoi.Joi.object().optional()
   }, resourceConfig.attributes);
 
   resourceConfig.onCreate = _.pick.apply(_, [].concat(resourceConfig.attributes, Object.keys(resourceConfig.attributes).filter(function(i) {

--- a/lib/ourJoi.js
+++ b/lib/ourJoi.js
@@ -8,7 +8,7 @@ ourJoi._joiBase = function(resourceName) {
   return Joi.object().keys({
     id: Joi.string().required(),
     type: Joi.any().required().valid(resourceName),
-    meta: Joi.any()
+    meta: Joi.object().optional()
   });
 };
 Joi.one = function(resource) {

--- a/lib/ourJoi.js
+++ b/lib/ourJoi.js
@@ -7,7 +7,8 @@ var Joi = require("joi");
 ourJoi._joiBase = function(resourceName) {
   return Joi.object().keys({
     id: Joi.string().required(),
-    type: Joi.any().required().valid(resourceName)
+    type: Joi.any().required().valid(resourceName),
+    meta: Joi.any()
   });
 };
 Joi.one = function(resource) {

--- a/lib/responseHelper.js
+++ b/lib/responseHelper.js
@@ -51,7 +51,9 @@ responseHelper._generateDataItem = function(item, schema) {
     return isSpecialProperty(schema[someProperty]);
   });
   var attributeProperties = Object.keys(schema).filter(function(someProperty) {
-    if ((someProperty === "id") || (someProperty === "type")) return false;
+    if (someProperty === "id") return false;
+    if (someProperty === "type") return false;
+    if (someProperty === "meta") return false;
     return !isSpecialProperty(schema[someProperty]);
   });
 
@@ -60,7 +62,8 @@ responseHelper._generateDataItem = function(item, schema) {
     id: item.id,
     attributes: _.pick(item, attributeProperties),
     links: responseHelper._generateLinks(item, schema, linkProperties),
-    relationships: responseHelper._generateRelationships(item, schema, linkProperties)
+    relationships: responseHelper._generateRelationships(item, schema, linkProperties),
+    meta: item.meta
   };
 
   return result;
@@ -106,7 +109,8 @@ responseHelper._generateLink = function(item, schemaProperty, linkProperty) {
       linkItems.forEach(function(linkItem) {
         link.data.push({
           type: linkItem.type,
-          id: linkItem.id
+          id: linkItem.id,
+          meta: linkItem.meta
         });
       });
     }
@@ -117,7 +121,8 @@ responseHelper._generateLink = function(item, schemaProperty, linkProperty) {
     if (linkItem) {
       link.data = {
         type: linkItem.type,
-        id: linkItem.id
+        id: linkItem.id,
+        meta: linkItem.meta
       };
     }
   }

--- a/lib/routes/create.js
+++ b/lib/routes/create.js
@@ -34,7 +34,7 @@ createRoute.register = function() {
         theirResource = _.extend({
           id: uuid.v4(),
           type: request.params.type
-        }, theirs.attributes);
+        }, theirs.attributes, { meta: theirs.meta });
         for (var i in theirs.relationships) {
           theirResource[i] = theirs.relationships[i].data;
         }

--- a/lib/routes/update.js
+++ b/lib/routes/update.js
@@ -33,7 +33,7 @@ updateRoute.register = function() {
         theirResource = _.extend({
           id: request.params.id,
           type: request.params.type
-        }, theirs.attributes);
+        }, theirs.attributes, { meta: theirs.meta });
         for (var i in theirs.relationships) {
           theirResource[i] = theirs.relationships[i].data;
         }

--- a/test/get-:resource-:id-relationships-:related.js
+++ b/test/get-:resource-:id-relationships-:related.js
@@ -47,7 +47,7 @@ describe("Testing jsonapi-server", function() {
         if (!(someDataBlock instanceof Array)) someDataBlock = [ someDataBlock ];
         someDataBlock.forEach(function(dataBlock) {
           var keys = Object.keys(dataBlock);
-          assert.deepEqual(keys, [ "type", "id" ], "Relationship data blocks should have specific properties");
+          assert.deepEqual(keys, [ "type", "id", "meta" ], "Relationship data blocks should have specific properties");
           assert.equal(typeof dataBlock.id, "string", "Relationship data blocks id should be string");
           assert.equal(typeof dataBlock.type, "string", "Relationship data blocks type should be string");
         });

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -57,9 +57,9 @@ testHelpers.validateRelationship = function(relationship) {
   var someDataBlock = relationship.data;
   if (!(someDataBlock instanceof Array)) someDataBlock = [ someDataBlock ];
   someDataBlock.forEach(function(dataBlock) {
-    keys = Object.keys(dataBlock);
-    assert.deepEqual(keys, [ "type", "id" ], "Relationship data blocks should have specific properties");
+    assert.ok(dataBlock.id, "Relationship block should have an id");
     assert.equal(typeof dataBlock.id, "string", "Relationship data blocks id should be string");
+    assert.ok(dataBlock.type, "Relationship block should have a type");
     assert.equal(typeof dataBlock.type, "string", "Relationship data blocks type should be string");
   });
 };

--- a/test/patch-:resource-:id-relationships-:related.js
+++ b/test/patch-:resource-:id-relationships-:related.js
@@ -70,7 +70,7 @@ describe("Testing jsonapi-server", function() {
             "Content-Type": "application/json"
           },
           body: JSON.stringify({
-            "data": { "type": "people", "id": "ad3aa89e-9c5b-4ac9-a652-6670f9f27587" }
+            "data": { "type": "people", "id": "ad3aa89e-9c5b-4ac9-a652-6670f9f27587", meta: { updated: "2012-01-01" } }
           })
         };
         request(data, function(err, res, json) {
@@ -97,7 +97,10 @@ describe("Testing jsonapi-server", function() {
 
           assert.deepEqual(json.data, {
             "type": "people",
-            "id": "ad3aa89e-9c5b-4ac9-a652-6670f9f27587"
+            "id": "ad3aa89e-9c5b-4ac9-a652-6670f9f27587",
+            "meta": {
+              "updated": "2012-01-01"
+            }
           });
 
           done();

--- a/test/patch-:resource-:id.js
+++ b/test/patch-:resource-:id.js
@@ -84,6 +84,9 @@ describe("Testing jsonapi-server", function() {
                 "author": {
                   "data": { "type": "people", "id": "d850ea75-4427-4f81-8595-039990aeede5" }
                 }
+              },
+              "meta": {
+                "created": "2013-01-01"
               }
             }
           })
@@ -148,6 +151,9 @@ describe("Testing jsonapi-server", function() {
                   "related": "/rest/articles/?relationships[comments]=3f1a89c2-eb85-4799-a048-6735db24b7eb"
                 }
               }
+            },
+            "meta": {
+              "created": "2013-01-01"
             }
           });
 

--- a/test/post-:resource-:id-relationships-:related.js
+++ b/test/post-:resource-:id-relationships-:related.js
@@ -70,7 +70,7 @@ describe("Testing jsonapi-server", function() {
             "Content-Type": "application/json"
           },
           body: JSON.stringify({
-            "data": { "type": "comments", "id": "6b017640-827c-4d50-8dcc-79d766abb408" }
+            "data": { "type": "comments", "id": "6b017640-827c-4d50-8dcc-79d766abb408", meta: { "updated": "2016-01-01" } }
           })
         };
         request(data, function(err, res, json) {
@@ -102,7 +102,10 @@ describe("Testing jsonapi-server", function() {
             },
             {
               "type": "comments",
-              "id": "6b017640-827c-4d50-8dcc-79d766abb408"
+              "id": "6b017640-827c-4d50-8dcc-79d766abb408",
+              "meta": {
+                "updated": "2016-01-01"
+              }
             }
           ]);
 

--- a/test/post-:resource.js
+++ b/test/post-:resource.js
@@ -90,6 +90,9 @@ describe("Testing jsonapi-server", function() {
                 "photographer": {
                   "data": { "type": "people", "id": "cc5cca2e-0dd8-4b95-8cfc-a11230e73116" }
                 }
+              },
+              "meta": {
+                "created": "2015-01-01"
               }
             }
           })
@@ -116,6 +119,7 @@ describe("Testing jsonapi-server", function() {
           assert.equal(res.statusCode, "200", "Expecting 200 OK");
           assert.equal(json.included.length, 0, "Should be no included resources");
           helpers.validatePhoto(json.data);
+          assert.deepEqual(json.data.meta, { created: "2015-01-01" });
 
           done();
         });


### PR DESCRIPTION
I've extended one of the example "articles" resources in /example/resource/articles.js to include metadata about an articles author and I've added generic metadata about the article iself. The example resource looks like this:
```javascript
{
  id: "de305d54-75b4-431b-adb2-eb6b9e546014",
  type: "articles",
  // ...
  author: {
    type: "people",
    id: "cc5cca2e-0dd8-4b95-8cfc-a11230e73116",
    meta: { updated: "2010-11-06" }
  },
  // ...
  meta: {
    updated: "2011-05-10"
  }
}
```

Fetching the above resource correctly places the meta blocks in the response:
http://localhost:16006/rest/articles/de305d54-75b4-431b-adb2-eb6b9e546014
```javascript
{
  // ...
  data: {
    type: "articles",
    id: "de305d54-75b4-431b-adb2-eb6b9e546014",
    // ...
    relationships: {
      author: {
        // ...
        data: {
          type: "people",
          id: "cc5cca2e-0dd8-4b95-8cfc-a11230e73116",
          meta: {
            updated: "2010-11-06"
          }
        }
      }
      // ...
    }
    // ...
    meta: {
      updated: "2011-05-10"
    }
  },
  // ...
}
```

Viewing the relationship itself also shows the metadata:
http://localhost:16006/rest/articles/de305d54-75b4-431b-adb2-eb6b9e546014/relationships/author
```javascript
{
  meta: {
    copyright: "Blah"
  },
  links: {
    self: "/rest/articles/de305d54-75b4-431b-adb2-eb6b9e546014/relationships/author"
  },
  data: {
    type: "people",
    id: "cc5cca2e-0dd8-4b95-8cfc-a11230e73116",
    meta: {
      updated: "2010-11-06"
    }
  }
}
```
