### PR TITLE
Stricter handling on Content-Type and Accept HTTP headers

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -8,6 +8,38 @@ var server;
 var bodyParser = require("body-parser");
 var jsonApi = require("./jsonApi.js");
 
+app.use(function(req, res, next) {
+  if (!req.headers["content-type"] && !req.headers.accept) return next();
+
+  if (req.headers["content-type"]) {
+    // 415 Unsupported Media Type
+    if (req.headers["content-type"].match(/^application\/vnd\.api\+json;.+$/)) {
+      return res.status(415).end();
+    }
+
+    // Convert "application/vnd.api+json" content type to "application/json".
+    // This enables the express body parser to correctly parse the JSON payload.
+    if (req.headers["content-type"].match(/^application\/vnd\.api\+json$/)) {
+      req.headers["content-type"] = "application/json";
+    }
+  }
+
+  if (req.headers.accept) {
+    // 406 Not Acceptable
+    var matchingTypes = req.headers.accept.split(/, ?/);
+    matchingTypes = matchingTypes.filter(function(mediaType) {
+      // Accept application/*, */vnd.api+json, */* and the correct JSON:API type.
+      return mediaType.match(/^(\*|application)\/(\*|vnd\.api\+json)$/);
+    });
+
+    if (matchingTypes.length === 0) {
+      return res.status(406).end();
+    }
+  }
+
+  return next();
+});
+
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
 app.disable("x-powered-by");

--- a/test/delete-:resource-:id-relationships-:related.js
+++ b/test/delete-:resource-:id-relationships-:related.js
@@ -26,7 +26,7 @@ describe("Testing jsonapi-server", function() {
         method: "delete",
         url: "http://localhost:16006/rest/articles/foobar/relationships/photos",
         headers: {
-          "Content-Type": "application/json"
+          "Content-Type": "application/vnd.api+json"
         },
         body: JSON.stringify({
           "data": { "type": "people", "id": "fa2a073f-8c64-4cbb-9158-b8f67a4ab9f5" }
@@ -46,7 +46,7 @@ describe("Testing jsonapi-server", function() {
         method: "delete",
         url: "http://localhost:16006/rest/articles/fa2a073f-8c64-4cbb-9158-b8f67a4ab9f5/relationships/tags",
         headers: {
-          "Content-Type": "application/json"
+          "Content-Type": "application/vnd.api+json"
         },
         body: JSON.stringify({
           "data": { "type": "tags", "id": "foobar" }
@@ -66,7 +66,7 @@ describe("Testing jsonapi-server", function() {
         method: "delete",
         url: "http://localhost:16006/rest/articles/fa2a073f-8c64-4cbb-9158-b8f67a4ab9f5/relationships/tags",
         headers: {
-          "Content-Type": "application/json"
+          "Content-Type": "application/vnd.api+json"
         },
         body: JSON.stringify({
           "data": { "type": "people", "id": "7541a4de-4986-4597-81b9-cf31b6762486" }
@@ -87,7 +87,7 @@ describe("Testing jsonapi-server", function() {
           method: "delete",
           url: "http://localhost:16006/rest/articles/fa2a073f-8c64-4cbb-9158-b8f67a4ab9f5/relationships/tags",
           headers: {
-            "Content-Type": "application/json"
+            "Content-Type": "application/vnd.api+json"
           },
           body: JSON.stringify({
             "data": { "type": "tags", "id": "7541a4de-4986-4597-81b9-cf31b6762486" }

--- a/test/patch-:resource-:id-relationships-:related.js
+++ b/test/patch-:resource-:id-relationships-:related.js
@@ -26,7 +26,7 @@ describe("Testing jsonapi-server", function() {
         method: "patch",
         url: "http://localhost:16006/rest/comments/foobar/relationships/author",
         headers: {
-          "Content-Type": "application/json"
+          "Content-Type": "application/vnd.api+json"
         },
         body: JSON.stringify({
           "data": { "type": "people", "id": "ad3aa89e-9c5b-4ac9-a652-6670f9f27587" }
@@ -46,7 +46,7 @@ describe("Testing jsonapi-server", function() {
         method: "patch",
         url: "http://localhost:16006/rest/comments/3f1a89c2-eb85-4799-a048-6735db24b7eb/relationships/article",
         headers: {
-          "Content-Type": "application/json"
+          "Content-Type": "application/vnd.api+json"
         },
         body: JSON.stringify({
           "data": { "type": "articles", "id": "de305d54-75b4-431b-adb2-eb6b9e546014" }
@@ -67,7 +67,7 @@ describe("Testing jsonapi-server", function() {
           method: "patch",
           url: "http://localhost:16006/rest/comments/3f1a89c2-eb85-4799-a048-6735db24b7eb/relationships/author",
           headers: {
-            "Content-Type": "application/json"
+            "Content-Type": "application/vnd.api+json"
           },
           body: JSON.stringify({
             "data": { "type": "people", "id": "ad3aa89e-9c5b-4ac9-a652-6670f9f27587" }

--- a/test/patch-:resource-:id.js
+++ b/test/patch-:resource-:id.js
@@ -26,7 +26,7 @@ describe("Testing jsonapi-server", function() {
         method: "patch",
         url: "http://localhost:16006/rest/comments/foobar",
         headers: {
-          "Content-Type": "application/json"
+          "Content-Type": "application/vnd.api+json"
         },
         body: JSON.stringify({
           "data": {
@@ -48,7 +48,7 @@ describe("Testing jsonapi-server", function() {
         method: "patch",
         url: "http://localhost:16006/rest/comments/3f1a89c2-eb85-4799-a048-6735db24b7eb",
         headers: {
-          "Content-Type": "application/json"
+          "Content-Type": "application/vnd.api+json"
         },
         body: JSON.stringify({
           "data": {
@@ -73,7 +73,7 @@ describe("Testing jsonapi-server", function() {
           method: "patch",
           url: "http://localhost:16006/rest/comments/3f1a89c2-eb85-4799-a048-6735db24b7eb",
           headers: {
-            "Content-Type": "application/json"
+            "Content-Type": "application/vnd.api+json"
           },
           body: JSON.stringify({
             "data": {

--- a/test/post-:resource-:id-relationships-:related.js
+++ b/test/post-:resource-:id-relationships-:related.js
@@ -26,7 +26,7 @@ describe("Testing jsonapi-server", function() {
         method: "post",
         url: "http://localhost:16006/rest/articles/foobar/relationships/author",
         headers: {
-          "Content-Type": "application/json"
+          "Content-Type": "application/vnd.api+json"
         },
         body: JSON.stringify({
           "data": { "type": "people", "id": "ad3aa89e-9c5b-4ac9-a652-6670f9f27587" }
@@ -46,7 +46,7 @@ describe("Testing jsonapi-server", function() {
         method: "post",
         url: "http://localhost:16006/rest/articles/fa2a073f-8c64-4cbb-9158-b8f67a4ab9f5/relationships/comments",
         headers: {
-          "Content-Type": "application/json"
+          "Content-Type": "application/vnd.api+json"
         },
         body: JSON.stringify({
           "data": { "type": "people", "id": "6b017640-827c-4d50-8dcc-79d766abb408" }
@@ -67,7 +67,7 @@ describe("Testing jsonapi-server", function() {
           method: "post",
           url: "http://localhost:16006/rest/articles/de305d54-75b4-431b-adb2-eb6b9e546014/relationships/comments",
           headers: {
-            "Content-Type": "application/json"
+            "Content-Type": "application/vnd.api+json"
           },
           body: JSON.stringify({
             "data": { "type": "comments", "id": "6b017640-827c-4d50-8dcc-79d766abb408" }

--- a/test/post-:resource.js
+++ b/test/post-:resource.js
@@ -26,7 +26,7 @@ describe("Testing jsonapi-server", function() {
         method: "post",
         url: "http://localhost:16006/rest/photos",
         headers: {
-          "Content-Type": "application/json"
+          "Content-Type": "application/vnd.api+json"
         },
         body: JSON.stringify({
           "data": {
@@ -48,6 +48,44 @@ describe("Testing jsonapi-server", function() {
         assert.equal(err, null);
         json = helpers.validateError(json);
         assert.equal(res.statusCode, "403", "Expecting 403");
+
+        done();
+      });
+    });
+
+    it("errors if content-type specifies a media type parameter", function(done) {
+      var data = {
+        method: "post",
+        url: "http://localhost:16006/rest/photos",
+        headers: {
+          "Content-Type": "application/vnd.api+json;foobar"
+        },
+        body: JSON.stringify({
+          "data": { }
+        })
+      };
+      request(data, function(err, res) {
+        assert.equal(err, null);
+        assert.equal(res.statusCode, "415", "Expecting 415");
+
+        done();
+      });
+    });
+
+    it("errors if accept header doesnt match JSON:APIs type", function(done) {
+      var data = {
+        method: "post",
+        url: "http://localhost:16006/rest/photos",
+        headers: {
+          "Accept": "application/vnd.api+xml, application/vnd.api+json;foobar, application/json"
+        },
+        body: JSON.stringify({
+          "data": { }
+        })
+      };
+      request(data, function(err, res) {
+        assert.equal(err, null);
+        assert.equal(res.statusCode, "406", "Expecting 406");
 
         done();
       });
@@ -75,7 +113,7 @@ describe("Testing jsonapi-server", function() {
           method: "post",
           url: "http://localhost:16006/rest/photos",
           headers: {
-            "Content-Type": "application/json"
+            "Content-Type": "application/vnd.api+json"
           },
           body: JSON.stringify({
             "data": {


### PR DESCRIPTION
This work adds stricter handling of HTTP headers:

- Requests without a Content-Type header will continue as usual.
- Requests with a Content-Type header of `application/vnd.api+json` will be parsed as JSON and function as expected.
- Requests with a Content-Type header matching `application/vnd.api+json` that ALSO contain a media type parameter (eg `application/vnd.api+json;foobar`) will receive a `HTTP 415`.

also:

- Requests without an Accept header will continue as usual.
- Requests with an Accept header that doesn't match `application/*`, `*/vnd.api+json`, `*/*` or `application/vnd.api+json` will receive a `HTTP 406`.

This work addresses #17 