### PR TITLE
Adding cookies to request

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -6,10 +6,12 @@ var express = require("express");
 var app = express();
 var server;
 var bodyParser = require("body-parser");
+var cookieParser = require('cookie-parser');
 var jsonApi = require("./jsonApi.js");
 
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
+app.use(cookieParser());
 app.disable("x-powered-by");
 app.disable("etag");
 
@@ -63,6 +65,7 @@ router._getParams = function(req) {
   return {
     params: _.extend(req.params, req.body, req.query),
     headers: req.headers,
+    cookies: req.cookies,
     route: {
       host: req.headers.host,
       base: jsonApi._apiConfig.base,

--- a/lib/router.js
+++ b/lib/router.js
@@ -6,7 +6,7 @@ var express = require("express");
 var app = express();
 var server;
 var bodyParser = require("body-parser");
-var cookieParser = require('cookie-parser');
+var cookieParser = require("cookie-parser");
 var jsonApi = require("./jsonApi.js");
 
 app.use(bodyParser.json());

--- a/package.json
+++ b/package.json
@@ -10,21 +10,22 @@
   "main": "lib/jsonApi.js",
   "author": "Oliver Rumbelow",
   "license": "MIT",
-  "repository" : {
-    "type" : "git",
-    "url" : "https://github.com/holidayextras/jsonapi-server"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/holidayextras/jsonapi-server"
   },
-  "engines" : {
-    "node" : "*"
+  "engines": {
+    "node": "*"
   },
   "dependencies": {
     "async": "1.3.0",
     "body-parser": "1.13.2",
+    "cookie-parser": "1.4.0",
     "express": "4.13.1",
     "joi": "6.5.0",
+    "node-uuid": "1.4.3",
     "request": "2.58.0",
-    "underscore": "1.8.3",
-    "node-uuid": "1.4.3"
+    "underscore": "1.8.3"
   },
   "devDependencies": {
     "mocha": "2.2.5",


### PR DESCRIPTION
Parse the cookies in all HTTP requests and make them available within the `request` object.