### PR TITLE
Validate attribute names

### DIFF
--- a/lib/jsonApi.js
+++ b/lib/jsonApi.js
@@ -42,6 +42,12 @@ jsonApi.define = function(resourceConfig) {
     resourceConfig.handlers.initialise(resourceConfig);
   }
 
+  Object.keys(resourceConfig.attributes).forEach(function(attribute) {
+    if (!attribute.match(/^[A-Za-z0-9\-\_]*$/)) {
+      throw new Error("Attribute '" + attribute + "' on " + resourceConfig.resource + " contains illegal characters!");
+    }
+  });
+
   resourceConfig.searchParams = _.extend({
     type: ourJoi.Joi.any().required().valid(resourceConfig.resource)
       .description("Always \"" + resourceConfig.resource + "\"")


### PR DESCRIPTION
```
The following "globally allowed characters" MAY be used anywhere in a member name:

U+0061 to U+007A, "a-z"
U+0041 to U+005A, "A-Z"
U+0030 to U+0039, "0-9"
any UNICODE character except U+0000 to U+007F (not recommended, not URL safe)
Additionally, the following characters are allowed in member names, except as the first or last character:

U+002D HYPHEN-MINUS, "-"
U+005F LOW LINE, "_"
U+0020 SPACE, " " (not recommended, not URL safe)
```