### PR TITLE
Allow null values when updating a resources relations

### DIFF
--- a/lib/ourJoi.js
+++ b/lib/ourJoi.js
@@ -5,11 +5,16 @@ var ourJoi = module.exports = { };
 var Joi = require("joi");
 
 ourJoi._joiBase = function(resourceName) {
-  return Joi.object().keys({
+  var relationType = Joi.object().keys({
     id: Joi.string().required(),
     type: Joi.any().required().valid(resourceName),
     meta: Joi.object().optional()
   });
+  return Joi.alternatives().try(
+    Joi.any().valid(null), // null
+    relationType           // relation
+  );
+
 };
 Joi.one = function(resource) {
   var obj = ourJoi._joiBase(resource);

--- a/test/patch-:resource-:id.js
+++ b/test/patch-:resource-:id.js
@@ -160,6 +160,96 @@ describe("Testing jsonapi-server", function() {
           done();
         });
       });
+
+      it("deletes a relationship", function(done) {
+        var data = {
+          method: "patch",
+          url: "http://localhost:16006/rest/comments/3f1a89c2-eb85-4799-a048-6735db24b7eb",
+          headers: {
+            "Content-Type": "application/vnd.api+json"
+          },
+          body: JSON.stringify({
+            "data": {
+              "attributes": {
+                "timestamp": "2017-06-29"
+              },
+              "relationships": {
+                "author": {
+                  "data": null
+                }
+              },
+              "meta": {
+                "created": "2013-01-01"
+              }
+            }
+          })
+        };
+        request(data, function(err, res, json) {
+          assert.equal(err, null);
+          json = helpers.validateJson(json);
+
+          var keys = Object.keys(json);
+          assert.deepEqual(keys, [ "meta", "links", "data" ], "Should have meta, links and data");
+          assert.equal(res.statusCode, "201", "Expecting 201");
+
+          done();
+        });
+      });
+
+      it("new resource has changed", function(done) {
+        var url = "http://localhost:16006/rest/comments/3f1a89c2-eb85-4799-a048-6735db24b7eb";
+        request.get(url, function(err, res, json) {
+          assert.equal(err, null);
+          json = helpers.validateJson(json);
+
+          var keys = Object.keys(json);
+          assert.deepEqual(keys, [ "meta", "links", "data", "included" ], "Should have meta, links, data and included");
+          assert.equal(res.statusCode, "200", "Expecting 200");
+
+          assert.deepEqual(json.data, {
+            "type": "comments",
+            "id": "3f1a89c2-eb85-4799-a048-6735db24b7eb",
+            "attributes": {
+              "body": "I like XML better",
+              "timestamp": "2017-06-29"
+            },
+            "links": {
+              "self": "/rest/comments/3f1a89c2-eb85-4799-a048-6735db24b7eb"
+            },
+            "relationships": {
+              "author": {
+                "meta": {
+                  "relation": "primary",
+                  "readOnly": false
+                },
+                "links": {
+                  "self": "/rest/comments/3f1a89c2-eb85-4799-a048-6735db24b7eb/relationships/author",
+                  "related": "/rest/comments/3f1a89c2-eb85-4799-a048-6735db24b7eb/author"
+                },
+                "data": null
+              },
+              "article": {
+                "meta": {
+                  "relation": "foreign",
+                  "belongsTo": "articles",
+                  "as": "comments",
+                  "readOnly": true,
+                  "many": false
+                },
+                "links": {
+                  "self": "/rest/articles/relationships/?comments=3f1a89c2-eb85-4799-a048-6735db24b7eb",
+                  "related": "/rest/articles/?relationships[comments]=3f1a89c2-eb85-4799-a048-6735db24b7eb"
+                }
+              }
+            },
+            "meta": {
+              "created": "2013-01-01"
+            }
+          });
+
+          done();
+        });
+      });
     });
   });
 


### PR DESCRIPTION
Allow us to remove a related resource by `patch`ing a null value:
```
"data": {
  "relationships": {
    "author": {
      "data": null
    }
  },
}
```
In master this gives a validation warning. It shouldn't.
