### PR TITLE
Always use absolute urls

### DIFF
--- a/documentation/configuring.md
+++ b/documentation/configuring.md
@@ -3,11 +3,15 @@
 
 ```
 jsonApi.setConfig({
+  // HTTP / HTTPS
+  protocol: "http",
+  // The hostname the API will be sat behind, from the customer's perspective
+  hostname: "localhost",
+  // The port the customer will be using (OPTIONAL)
+  port: 16006,
   // Define a url prefix for the apiConfig
   // eg http://-----/rest/
   base: "rest",
-  // HTTP port to listen on
-  port: 16006,
   // meta block to appear in the root of every response
   meta: {
     copyright: "Blah"

--- a/documentation/foreign-relations.md
+++ b/documentation/foreign-relations.md
@@ -153,9 +153,9 @@ relationships: {
     },
     links: {
       // get information about the linkage - list of ids and types
-      self: "/rest/comments/6b017640-827c-4d50-8dcc-79d766abb408/relationships/author",
+      self: "http://localhost:16006/rest/comments/6b017640-827c-4d50-8dcc-79d766abb408/relationships/author",
       // get full details of all linked resources
-      related: "/rest/comments/6b017640-827c-4d50-8dcc-79d766abb408/author"
+      related: "http://localhost:16006/rest/comments/6b017640-827c-4d50-8dcc-79d766abb408/author"
     },
     data: {
       type: "people",
@@ -172,9 +172,9 @@ relationships: {
     },
     links: {
       // get information about the linkage - list of ids and types
-      self: "/rest/articles/relationships/?comments=6b017640-827c-4d50-8dcc-79d766abb408",
+      self: "http://localhost:16006/rest/articles/relationships/?comments=6b017640-827c-4d50-8dcc-79d766abb408",
       // get full details of all linked resources (perform a search against the foreign key)
-      related: "/rest/articles/?relationships[comments]=6b017640-827c-4d50-8dcc-79d766abb408"
+      related: "http://localhost:16006/rest/articles/?relationships[comments]=6b017640-827c-4d50-8dcc-79d766abb408"
     }
   }
 }

--- a/example/server.js
+++ b/example/server.js
@@ -6,10 +6,10 @@ var fs = require("fs");
 var path = require("path");
 
 jsonApi.setConfig({
-  base: "rest",
   protocol: "http",
   hostname: "localhost",
   port: 16006,
+  base: "rest",
   meta: {
     copyright: "Blah"
   }

--- a/example/server.js
+++ b/example/server.js
@@ -7,6 +7,8 @@ var path = require("path");
 
 jsonApi.setConfig({
   base: "rest",
+  protocol: "http",
+  hostname: "localhost",
   port: 16006,
   meta: {
     copyright: "Blah"

--- a/lib/jsonApi.js
+++ b/lib/jsonApi.js
@@ -9,6 +9,7 @@ var router = require("./router.js");
 var responseHelper = require("./responseHelper.js");
 var routes = require("./routes");
 var mockHandlers = require("./mockHandlers.js");
+var url = require("url");
 
 jsonApi.Joi = ourJoi.Joi;
 jsonApi.mockHandlers = mockHandlers.handlers;
@@ -24,12 +25,12 @@ jsonApi.setConfig = function(apiConfig) {
 jsonApi.authenticate = router.authenticateWith;
 
 jsonApi._concatenateUrlPrefix = function(config) {
-  var pathPrefix = "";
-  pathPrefix += (config.protocol || "https") + "://";
-  pathPrefix += (config.hostname || "localhost");
-  if (config.port) pathPrefix += ":" + config.port;
-  pathPrefix += config.base;
-  return pathPrefix;
+  return url.format({
+    protocol: config.protocol,
+    hostname: config.hostname,
+    port: config.port,
+    pathname: config.base
+  });
 };
 
 jsonApi._cleanBaseUrl = function(base) {

--- a/lib/jsonApi.js
+++ b/lib/jsonApi.js
@@ -16,11 +16,21 @@ jsonApi.mockHandlers = mockHandlers.handlers;
 jsonApi.setConfig = function(apiConfig) {
   jsonApi._apiConfig = apiConfig;
   jsonApi._apiConfig.base = jsonApi._cleanBaseUrl(jsonApi._apiConfig.base);
-  responseHelper.setBaseUrl(jsonApi._apiConfig.base);
+  jsonApi._apiConfig.pathPrefix = jsonApi._concatenateUrlPrefix(jsonApi._apiConfig);
+  responseHelper.setBaseUrl(jsonApi._apiConfig.pathPrefix);
   responseHelper.setMetadata(jsonApi._apiConfig.meta);
 };
 
 jsonApi.authenticate = router.authenticateWith;
+
+jsonApi._concatenateUrlPrefix = function(config) {
+  var pathPrefix = "";
+  pathPrefix += (config.protocol || "https") + "://";
+  pathPrefix += (config.hostname || "localhost");
+  if (config.port) pathPrefix += ":" + config.port;
+  pathPrefix += config.base;
+  return pathPrefix;
+};
 
 jsonApi._cleanBaseUrl = function(base) {
   if (!base) {

--- a/lib/postProcessing/include.js
+++ b/lib/postProcessing/include.js
@@ -115,7 +115,7 @@ includePP._fillIncludeTree = function(includeTree, request, callback) {
     return Object.keys(dataItem.relationships || { }).filter(function(keyName) {
       return (keyName[0] !== "_") && (includes.indexOf(keyName) !== -1);
     }).map(function(keyName) {
-      var url = "http://" + request.route.host + dataItem.relationships[keyName].links.related;
+      var url = dataItem.relationships[keyName].links.related;
       if (url.indexOf("?") === -1) url += "?";
       if (includeTree[keyName]._filter) {
         url += "&" + includeTree[keyName]._filter.join("&");

--- a/lib/responseHelper.js
+++ b/lib/responseHelper.js
@@ -157,7 +157,7 @@ responseHelper.generateError = function(request, err) {
   var errorResponse = {
     meta: responseHelper._generateMeta(request),
     links: {
-      self: request.route.path
+      self: responseHelper._baseUrl + request.route.path
     },
     errors: err.map(function(error) {
       return {
@@ -176,7 +176,7 @@ responseHelper._generateResponse = function(request, resourceConfig, sanitisedDa
   return {
     meta: responseHelper._generateMeta(request),
     links: {
-      self: request.route.path + (request.route.query ? ("?" + request.route.query) : "")
+      self: responseHelper._baseUrl + request.route.path + (request.route.query ? ("?" + request.route.query) : "")
     },
     data: sanitisedData
   };

--- a/lib/router.js
+++ b/lib/router.js
@@ -109,7 +109,10 @@ router.bindErrorHandler = function(callback) {
 };
 
 router._getParams = function(req) {
-  var urlParts = req.url.split("?");
+  var urlParts = req.url.split(jsonApi._apiConfig.base);
+  urlParts.shift();
+  urlParts = urlParts.join("").split("?");
+
   return {
     params: _.extend(req.params, req.body, req.query),
     headers: req.headers,
@@ -119,7 +122,7 @@ router._getParams = function(req) {
       base: jsonApi._apiConfig.base,
       path: urlParts.shift() || "",
       query: urlParts.shift() || "",
-      combined: "https://" + req.headers.host + req.url
+      combined: (jsonApi._apiConfig.protocol || "http") + "://" + req.headers.host + req.url
     }
   };
 };

--- a/lib/router.js
+++ b/lib/router.js
@@ -8,6 +8,7 @@ var server;
 var bodyParser = require("body-parser");
 var cookieParser = require("cookie-parser");
 var jsonApi = require("./jsonApi.js");
+var url = require("url");
 
 app.use(function(req, res, next) {
   if (!req.headers["content-type"] && !req.headers.accept) return next();
@@ -122,7 +123,11 @@ router._getParams = function(req) {
       base: jsonApi._apiConfig.base,
       path: urlParts.shift() || "",
       query: urlParts.shift() || "",
-      combined: (jsonApi._apiConfig.protocol || "http") + "://" + req.headers.host + req.url
+      combined: url.format({
+        protocol: jsonApi._apiConfig.protocol,
+        hostname: req.headers.host,
+        pathname: req.url
+      })
     }
   };
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-server",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "A fully featured NodeJS sever implementation of json:api. You provide the resources, we provide the api.",
   "keywords": [
     "jsonapi",

--- a/test/patch-:resource-:id.js
+++ b/test/patch-:resource-:id.js
@@ -121,7 +121,7 @@ describe("Testing jsonapi-server", function() {
               "timestamp": "2017-06-29"
             },
             "links": {
-              "self": "/rest/comments/3f1a89c2-eb85-4799-a048-6735db24b7eb"
+              "self": "http://localhost:16006/rest/comments/3f1a89c2-eb85-4799-a048-6735db24b7eb"
             },
             "relationships": {
               "author": {
@@ -130,8 +130,8 @@ describe("Testing jsonapi-server", function() {
                   "readOnly": false
                 },
                 "links": {
-                  "self": "/rest/comments/3f1a89c2-eb85-4799-a048-6735db24b7eb/relationships/author",
-                  "related": "/rest/comments/3f1a89c2-eb85-4799-a048-6735db24b7eb/author"
+                  "self": "http://localhost:16006/rest/comments/3f1a89c2-eb85-4799-a048-6735db24b7eb/relationships/author",
+                  "related": "http://localhost:16006/rest/comments/3f1a89c2-eb85-4799-a048-6735db24b7eb/author"
                 },
                 "data": {
                   "type": "people",
@@ -147,8 +147,8 @@ describe("Testing jsonapi-server", function() {
                   "many": false
                 },
                 "links": {
-                  "self": "/rest/articles/relationships/?comments=3f1a89c2-eb85-4799-a048-6735db24b7eb",
-                  "related": "/rest/articles/?relationships[comments]=3f1a89c2-eb85-4799-a048-6735db24b7eb"
+                  "self": "http://localhost:16006/rest/articles/relationships/?comments=3f1a89c2-eb85-4799-a048-6735db24b7eb",
+                  "related": "http://localhost:16006/rest/articles/?relationships[comments]=3f1a89c2-eb85-4799-a048-6735db24b7eb"
                 }
               }
             },
@@ -214,7 +214,7 @@ describe("Testing jsonapi-server", function() {
               "timestamp": "2017-06-29"
             },
             "links": {
-              "self": "/rest/comments/3f1a89c2-eb85-4799-a048-6735db24b7eb"
+              "self": "http://localhost:16006/rest/comments/3f1a89c2-eb85-4799-a048-6735db24b7eb"
             },
             "relationships": {
               "author": {
@@ -223,8 +223,8 @@ describe("Testing jsonapi-server", function() {
                   "readOnly": false
                 },
                 "links": {
-                  "self": "/rest/comments/3f1a89c2-eb85-4799-a048-6735db24b7eb/relationships/author",
-                  "related": "/rest/comments/3f1a89c2-eb85-4799-a048-6735db24b7eb/author"
+                  "self": "http://localhost:16006/rest/comments/3f1a89c2-eb85-4799-a048-6735db24b7eb/relationships/author",
+                  "related": "http://localhost:16006/rest/comments/3f1a89c2-eb85-4799-a048-6735db24b7eb/author"
                 },
                 "data": null
               },
@@ -237,8 +237,8 @@ describe("Testing jsonapi-server", function() {
                   "many": false
                 },
                 "links": {
-                  "self": "/rest/articles/relationships/?comments=3f1a89c2-eb85-4799-a048-6735db24b7eb",
-                  "related": "/rest/articles/?relationships[comments]=3f1a89c2-eb85-4799-a048-6735db24b7eb"
+                  "self": "http://localhost:16006/rest/articles/relationships/?comments=3f1a89c2-eb85-4799-a048-6735db24b7eb",
+                  "related": "http://localhost:16006/rest/articles/?relationships[comments]=3f1a89c2-eb85-4799-a048-6735db24b7eb"
                 }
               }
             },


### PR DESCRIPTION
Stop responding with relative URLs:
```
links: {
    self: "/rest/articles/de305d54-75b4-431b-adb2-eb6b9e546014?include=author"
},
```
and start using absolute URLs:
```
links: {
    self: "http://localhost:16006/rest/articles/de305d54-75b4-431b-adb2-eb6b9e546014?include=author"
},
```

I'm not 100% happy with this yet, but its a step in the right direction. I'm thinking about if we can decouple the domain name from the config and simply use whatever gets passed in per-request. It'd also be nice to run an API on a different port from what the customer see's to make better use of infrastructure. This stuff will become clearer in the next few weeks when we look at pushing this into production.