### PR TITLE
Improving validation on resource update

### DIFF
--- a/lib/ourJoi.js
+++ b/lib/ourJoi.js
@@ -10,14 +10,13 @@ ourJoi._joiBase = function(resourceName) {
     type: Joi.any().required().valid(resourceName),
     meta: Joi.object().optional()
   });
-  return Joi.alternatives().try(
-    Joi.any().valid(null), // null
-    relationType           // relation
-  );
-
+  return relationType;
 };
 Joi.one = function(resource) {
-  var obj = ourJoi._joiBase(resource);
+  var obj = Joi.alternatives().try(
+    Joi.any().valid(null), // null
+    ourJoi._joiBase(resource)
+  );
   obj._settings = {
     __one: resource
   };
@@ -31,7 +30,10 @@ Joi.many = function(resource) {
   return obj;
 };
 Joi.belongsToOne = function(config) {
-  var obj = ourJoi._joiBase(config.resource);
+  var obj = Joi.alternatives().try(
+    Joi.any().valid(null), // null
+    ourJoi._joiBase(config.resource)
+  );
   obj._settings = {
     __one: config.resource,
     __as: config.as

--- a/lib/routes/update.js
+++ b/lib/routes/update.js
@@ -37,7 +37,11 @@ updateRoute.register = function() {
         for (var i in theirs.relationships) {
           theirResource[i] = theirs.relationships[i].data;
         }
-        helper.validate(theirResource, resourceConfig.onCreate, callback);
+        callback();
+      },
+      function(callback) {
+        var validationObject = _.pick(resourceConfig.onCreate, Object.keys(theirResource));
+        helper.validate(theirResource, validationObject, callback);
       },
       function(callback) {
         resourceConfig.handlers.update(request, theirResource, callback);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-server",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "A fully featured NodeJS sever implementation of json:api. You provide the resources, we provide the api.",
   "keywords": [
     "jsonapi",


### PR DESCRIPTION
The JSON:API spec states:
```
Any or all of a resource's attributes MAY be included in the resource object included 
in a PATCH request.

If a request does not include all of the attributes for a resource, the server MUST
interpret the missing attributes as if they were included with their current values. 
```
When updating a resource, we're accepting a partial resource, we need to validate it accordingly. We now only validate the properties being updated.

The improved validation also gives errors when attempting to insert `null` or `undefined` values into a `many` relationship like this:
```
"data": {
  "relationships": {
    "tags": {
      "data": [ { ... }, undefined ]
    }
  }
}
```