### PR TITLE
Make sure only `.js` files are considered as routes.

### DIFF
--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -7,7 +7,7 @@ var path = require("path");
 
 routes.handlers = { };
 fs.readdirSync(__dirname).filter(function(filename) {
-  return (filename !== "index.js") && (filename !== "helper.js");
+  return /\.js$/.test(filename) && (filename !== "index.js") && (filename !== "helper.js");
 }).sort().forEach(function(filename) {
   routes.handlers[filename] = require(path.join(__dirname, filename));
 });


### PR DESCRIPTION
Be defensive and only try to read `.js` files as routes. I use [`tern`](http://ternjs.net/) which has a tendency to create its socket files everywhere in the tree and the router was trying to read these as route files and failing miserably.