### PR TITLE
Return `200 OK` for update routes success.

### DIFF
--- a/lib/routes/update.js
+++ b/lib/routes/update.js
@@ -62,7 +62,7 @@ updateRoute.register = function() {
       }
     ], function(err) {
       if (err) return helper.handleError(request, res, err);
-      router.sendResponse(res, response, 201);
+      router.sendResponse(res, response, 200);
     });
   });
 };

--- a/lib/routes/updateRelation.js
+++ b/lib/routes/updateRelation.js
@@ -57,7 +57,7 @@ updateRelationRoute.register = function() {
       }
     ], function(err) {
       if (err) return helper.handleError(request, res, err);
-      router.sendResponse(res, response, 201);
+      router.sendResponse(res, response, 200);
     });
   });
 };

--- a/test/patch-:resource-:id-relationships-:related.js
+++ b/test/patch-:resource-:id-relationships-:related.js
@@ -79,7 +79,7 @@ describe("Testing jsonapi-server", function() {
 
           var keys = Object.keys(json);
           assert.deepEqual(keys, [ "meta", "links", "data" ], "Should have meta, links and data");
-          assert.equal(res.statusCode, "201", "Expecting 201");
+          assert.equal(res.statusCode, "200", "Expecting 200");
 
           done();
         });

--- a/test/patch-:resource-:id.js
+++ b/test/patch-:resource-:id.js
@@ -172,7 +172,7 @@ describe("Testing jsonapi-server", function() {
 
         var keys = Object.keys(json);
         assert.deepEqual(keys, [ "meta", "links", "data" ], "Should have meta, links and data");
-        assert.equal(res.statusCode, "201", "Expecting 201");
+        assert.equal(res.statusCode, "200", "Expecting 200");
 
         done();
       });
@@ -208,7 +208,7 @@ describe("Testing jsonapi-server", function() {
 
           var keys = Object.keys(json);
           assert.deepEqual(keys, [ "meta", "links", "data" ], "Should have meta, links and data");
-          assert.equal(res.statusCode, "201", "Expecting 201");
+          assert.equal(res.statusCode, "200", "Expecting 200");
 
           done();
         });
@@ -301,7 +301,7 @@ describe("Testing jsonapi-server", function() {
 
           var keys = Object.keys(json);
           assert.deepEqual(keys, [ "meta", "links", "data" ], "Should have meta, links and data");
-          assert.equal(res.statusCode, "201", "Expecting 201");
+          assert.equal(res.statusCode, "200", "Expecting 200");
 
           done();
         });


### PR DESCRIPTION
`201 CREATED` should only be used for the `create` route.

`updateRelation` will have to be further tweaked since it should return a `204 NO CONTENT` for some cases, but at least `200` is a more correct response than `201` for now.