### PR TITLE
Pass auth headers+cookies around inclusions

### DIFF
--- a/lib/postProcess.js
+++ b/lib/postProcess.js
@@ -40,7 +40,11 @@ postProcess._fetchRelatedResources = function(request, mainResource, callback) {
     return "http://" + request.route.host + request.route.base + dataItem.type + "/" + dataItem.id;
   });
   async.map(resourcesToFetch, function(related, done) {
-    externalRequest.get(related, function(err, externalRes, json) {
+    externalRequest({
+      method: "GET",
+      uri: related,
+      headers: request.headers
+    }, function(err, externalRes, json) {
       if (err || !json) return done(null, [ ]);
 
       try {

--- a/lib/postProcessing/include.js
+++ b/lib/postProcessing/include.js
@@ -131,7 +131,12 @@ includePP._fillIncludeTree = function(includeTree, request, callback) {
     var parts = related.split("~~");
     var type = parts[0];
     var link = parts[1];
-    externalRequest.get(link, function(err, res, json) {
+
+    externalRequest({
+      method: "GET",
+      uri: link,
+      headers: request.headers
+    }, function(err, res, json) {
       if (err || !json) {
         return done(null);
       }


### PR DESCRIPTION
When using some kind of cookie based authentication, when making requests for related documents, we need to also pass around the original requests headers. This prevents subsequent requests from returning with `401 UNAUTHORISED`.