### PR TITLE
Adjust filter functionality and adds new test use cases

### DIFF
--- a/lib/postProcessing/filter.js
+++ b/lib/postProcessing/filter.js
@@ -59,10 +59,10 @@ filter._filterKeepObject = function(someObject, filters) {
   for (var k in filters) {
     var whitelist = filters[k].split(",");
     var propertyText = (someObject.attributes[k] || "");
-    var matchOR = false;
+    var matchOR = true;
     for (var j = 0; j < whitelist.length; j++) {
       var textToMatch = whitelist[j];
-      if (filter._filterMatches(textToMatch, propertyText)) matchOR = true;
+      if (filter._filterMatches(textToMatch, propertyText)) matchOR = false;
     }
     if (!matchOR) return false;
   }

--- a/test/get-:resource.js
+++ b/test/get-:resource.js
@@ -144,6 +144,34 @@ describe("Testing jsonapi-server", function() {
           done();
         });
       });
+
+      it('doesnt return with multiple filters if one returns false', function(done) {
+        var url = 'http://localhost:16006/rest/articles?filter[title]=:best&filter[title]=>Z';
+        request.get(url, function(err, res, json) {
+          assert.equal(err, null);
+          json = helpers.validateJson(json);
+
+          assert.equal(res.statusCode, "200", "Expecting 200 OK");
+          assert.deepEqual(json.data, []);
+
+          done();
+        });
+      });
+
+      it('returns when multiple filters match', function(done) {
+        var url = 'http://localhost:16006/rest/articles?filter[title]=:for&filter[content]=~NA';
+        request.get(url, function(err, res, json) {
+          assert.equal(err, null);
+          json = helpers.validateJson(json);
+
+          assert.equal(res.statusCode, "200", "Expecting 200 OK");
+          var titles = json.data.map(function(i) { return i.attributes.title; });
+          assert.deepEqual(titles, [ "Tea for Beginners" ], "expected matching resources");
+
+          done();
+        });
+      });
+
     });
 
     describe("applying fields", function() {


### PR DESCRIPTION
This ensures we only return a resource when it matches all filter constraints. Before this, if one filter constraint was met, the resource would be returned.

## To test this

Run the test suite, and check out the code to ensure test coverage is sufficient
Run locally and hit these endpoints:

This should return the resource - `http://localhost:16006/rest/articles?filter[title]=:for&filter[content]=~NA`
This should not return the resource - `http://localhost:16006/rest/articles?filter[title]=:best&filter[title]=>Z`

### Reviewer 1

- [ ] - I have read/understood the changes and agree with the test coverage

### Reviewer 2

- [ ]  - I have read/understood the changes and agree with the test coverage