### PR TITLE
Error when looking up a related foreign resource

### DIFF
--- a/lib/routes/related.js
+++ b/lib/routes/related.js
@@ -33,6 +33,14 @@ relatedRoute.register = function() {
             detail: "The requested relation does not exist within the requested type"
           });
         }
+        if (relation._settings.__as) {
+          return callback({
+            status: "404",
+            code: "EFOREIGN",
+            title: "Relation is Foreign",
+            detail: "The requested relation is a foreign relation and cannot be accessed in this manner."
+          });
+        }
         callback();
       },
       function(callback) {

--- a/test/get-:resource-:id-:related.js
+++ b/test/get-:resource-:id-:related.js
@@ -29,6 +29,18 @@ describe("Testing jsonapi-server", function() {
       });
     });
 
+    it("foreign relation should error", function(done) {
+      var url = "http://localhost:16006/rest/people/cc5cca2e-0dd8-4b95-8cfc-a11230e73116/articles";
+      request.get(url, function(err, res, json) {
+        assert.equal(err, null);
+        json = helpers.validateError(json);
+        assert.equal(json.errors[0].code, "EFOREIGN");
+        assert.equal(res.statusCode, "404", "Expecting 404");
+
+        done();
+      });
+    });
+
     it("Lookup by id", function(done) {
       var url = "http://localhost:16006/rest/articles/de305d54-75b4-431b-adb2-eb6b9e546014/author";
       request.get(url, function(err, res, json) {


### PR DESCRIPTION
On master right now if you try and query a resources related resources against a foreign relation, eg:

http://localhost:16006/rest/photos/aab14844-97e7-401c-98c8-0bd5ec922d93/articles

it'll crash out. This PR catches that edge case and gives the consumer a sensible error message.