### PR TITLE
Add additional detail for stock 404 and 403 errors

### DIFF
--- a/lib/routes/helper.js
+++ b/lib/routes/helper.js
@@ -44,7 +44,7 @@ helper.verifyRequest = function(request, resourceConfig, res, handlerRequest, ca
       status: "404",
       code: "ENOTFOUND",
       title: "Resource not found",
-      detail: "The requested resource does not exist"
+      detail: "The requested resource '" + request.params.type + "' does not exist"
     });
   }
 
@@ -53,7 +53,7 @@ helper.verifyRequest = function(request, resourceConfig, res, handlerRequest, ca
       status: "403",
       code: "EFORBIDDEN",
       title: "Resource not supported",
-      detail: "The requested resource is not supported"
+      detail: "The requested resource '" + request.params.type + "' does not support '" + handlerRequest + "'"
     });
   }
 


### PR DESCRIPTION
In master, it can be confusing as to why we're getting an error. This PR adds some clarity to the stock 404 and 403 error messages we get when requesting invalid resources, or when attempting to interact with resources in unsupported ways.