### PR TITLE
HTTPs related resource bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,3 +30,5 @@
 2015-11-10 - Additional error handling for foreign relation lookup
 2015-11-10 - Additional error detail on 403 and 404
 2015-11-10 - v0.12.0
+2015-11-11 - Correctly build related URLs when using HTTPS
+2015-11-11 - v0.12.1

--- a/lib/postProcess.js
+++ b/lib/postProcess.js
@@ -1,6 +1,7 @@
 "use strict";
 var postProcess = module.exports = { };
 
+var jsonApi = require("..");
 var _ = require("underscore");
 var externalRequest = require("request").defaults({
   pool: { maxSockets: Infinity }
@@ -37,7 +38,7 @@ postProcess._fetchRelatedResources = function(request, mainResource, callback) {
   if (!(dataItems instanceof Array)) dataItems = [ dataItems ];
 
   var resourcesToFetch = dataItems.map(function(dataItem) {
-    return "http://" + request.route.host + request.route.base + dataItem.type + "/" + dataItem.id;
+    return jsonApi._apiConfig.pathPrefix + dataItem.type + "/" + dataItem.id;
   });
   async.map(resourcesToFetch, function(related, done) {
     externalRequest({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-server",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "A fully featured NodeJS sever implementation of json:api. You provide the resources, we provide the api.",
   "keywords": [
     "jsonapi",


### PR DESCRIPTION
When making requests for related resources we were incorrectly build the URL. Previously we were always using `HTTP` even for `HTTPS` requests, which can lead to garbled encrypted payloads with a `200 OK` header. Now, we're using the correctly generated path prefix.