### PR TITLE
Blacklist headers that shouldnt be forwarded on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,3 +32,5 @@
 2015-11-10 - v0.12.0
 2015-11-11 - Correctly build related URLs when using HTTPS
 2015-11-11 - v0.12.1
+2015-11-11 - Blacklist some HTTP headers we dont want to pass onwards
+2015-11-11 - v0.12.2

--- a/lib/postProcess.js
+++ b/lib/postProcess.js
@@ -44,7 +44,7 @@ postProcess._fetchRelatedResources = function(request, mainResource, callback) {
     externalRequest({
       method: "GET",
       uri: related,
-      headers: request.headers
+      headers: request.safeHeaders
     }, function(err, externalRes, json) {
       if (err || !json) return done(null, [ ]);
 

--- a/lib/postProcessing/include.js
+++ b/lib/postProcessing/include.js
@@ -135,7 +135,7 @@ includePP._fillIncludeTree = function(includeTree, request, callback) {
     externalRequest({
       method: "GET",
       uri: link,
-      headers: request.headers
+      headers: request.safeHeaders
     }, function(err, res, json) {
       if (err || !json) {
         return done(null);

--- a/lib/router.js
+++ b/lib/router.js
@@ -114,9 +114,14 @@ router._getParams = function(req) {
   urlParts.shift();
   urlParts = urlParts.join("").split("?");
 
+  var headersToRemove = [
+    "host", "connection", "accept-encoding", "accept-language"
+  ];
+
   return {
     params: _.extend(req.params, req.body, req.query),
     headers: req.headers,
+    safeHeaders: _.omit(req.headers, headersToRemove),
     cookies: req.cookies,
     route: {
       host: req.headers.host,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-server",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "A fully featured NodeJS sever implementation of json:api. You provide the resources, we provide the api.",
   "keywords": [
     "jsonapi",


### PR DESCRIPTION
In master, when we make subsequent requests for additional resources, we're passing around the originating headers to enable authentication and other header-specific mechanisms to function. However. There are some headers that don't play nicely, such as:

```
     host: 'localhost:16006',
     'accept-encoding': 'gzip, deflate, sdch',
``

This PR blacklists a subset of headers that we'll never want to pass onwards.