### PR TITLE
Ready property and check for handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,3 +34,5 @@
 2015-11-11 - v0.12.1
 2015-11-11 - Blacklist some HTTP headers we dont want to pass onwards
 2015-11-11 - v0.12.2
+2015-11-12 - Handlers readiness check
+2015-11-12 - v0.13.0

--- a/documentation/handlers.md
+++ b/documentation/handlers.md
@@ -1,12 +1,15 @@
 ### Creating Custom Handlers
 
-Handlers represent the mechanism that backs a resource. Each handler is expected to provide some of the following functions:
-* initialise - when jsonapi-server loads, this is invoked once for every resource using this handler. Its an opportunity to allocate memory, connect to databases, etc.
-* search - for searching for resources that match some vague parameters.
-* find - for finding a specific resource by id.
-* create - for creating a new instance of a resource.
-* delete - for deleting an existing resource.
-* update - for updating an existing resource.
+Handlers represent the mechanism that backs a resource. Each handler is expected to provide:
+
+* a `ready` property indicating the handler is ready to process requests.
+* some of the following functions:
+ * `initialise` - when jsonapi-server loads, this is invoked once for every resource using this handler. Its an opportunity to allocate memory, connect to databases, etc.
+ * `search` - for searching for resources that match some vague parameters.
+ * `find` - for finding a specific resource by id.
+ * `create` - for creating a new instance of a resource.
+ * `delete` - for deleting an existing resource.
+ * `update` - for updating an existing resource.
 
 Failure to provide the above handler functions will result in `EFORBIDDEN` HTTP errors if the corresponding REST routes are requested.
 
@@ -63,6 +66,10 @@ All errors should be provided in the following format:
   detail: "There is no "+request.params.type+" with id "+request.params.id
 }
 ```
+
+#### ready
+
+The `ready` property should be set to a _truthy_ value once the handler is ready to process requests (which will usually happen at the end of `initialise`). If the handler is temporarily unable to process requests this property should be set to a _falsy_ value during the down period.
 
 #### initialise
 `initialise` is invoked with the `resourceConfig` of each resource using this handler.

--- a/lib/mockHandlers.js
+++ b/lib/mockHandlers.js
@@ -7,11 +7,17 @@ var _ = require("underscore");
 var resources = { };
 
 /**
+  Handlers readiness status. This should be set to `true` once all handlers are ready to process requests.
+ */
+memoryStore.handlers.ready = false;
+
+/**
   initialise gets invoked once for each resource that uses this hander.
   In this instance, we're allocating an array in our in-memory data store.
  */
 memoryStore.handlers.initialise = function(resourceConfig) {
   resources[resourceConfig.resource] = resourceConfig.examples || [ ];
+  memoryStore.handlers.ready = true;
 };
 
 /**

--- a/lib/routes/helper.js
+++ b/lib/routes/helper.js
@@ -48,6 +48,15 @@ helper.verifyRequest = function(request, resourceConfig, res, handlerRequest, ca
     });
   }
 
+  if (!resourceConfig.handlers.ready) {
+    return helper.handleError(request, res, {
+      status: "503",
+      code: "EUNAVAILABLE",
+      title: "Resource not available",
+      detail: "The requested resource '" + request.params.type + "' is temporarily unavailable"
+    });
+  }
+
   if (!resourceConfig.handlers[handlerRequest]) {
     return helper.handleError(request, res, {
       status: "403",

--- a/lib/routes/helper.js
+++ b/lib/routes/helper.js
@@ -52,7 +52,7 @@ helper.verifyRequest = function(request, resourceConfig, res, handlerRequest, ca
     return helper.handleError(request, res, {
       status: "503",
       code: "EUNAVAILABLE",
-      title: "Resource not available",
+      title: "Resource temporarily unavailable",
       detail: "The requested resource '" + request.params.type + "' is temporarily unavailable"
     });
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-server",
-  "version": "0.12.2",
+  "version": "0.13.0",
   "description": "A fully featured NodeJS sever implementation of json:api. You provide the resources, we provide the api.",
   "keywords": [
     "jsonapi",

--- a/test/503.js
+++ b/test/503.js
@@ -1,0 +1,42 @@
+"use strict";
+var request = require("request");
+var assert = require("assert");
+var jsonApi = require("../lib/jsonApi");
+var jsonApiTestServer = require("../example/server");
+
+
+describe("Testing jsonapi-server", function() {
+
+  describe("resource readiness", function() {
+
+    it("returns 200 if resource is ready", function(done) {
+      var url = "http://localhost:16006/rest/articles/de305d54-75b4-431b-adb2-eb6b9e546014";
+      request.get(url, function(err, res) {
+        assert(!err);
+        assert.strictEqual(res.statusCode, 200, "Expecting 200 OK");
+        done();
+      });
+    });
+
+    it("returns 503 if resource is NOT ready", function(done) {
+      var handlers = jsonApi._resources.articles.handlers;
+      var savedHandlersReady = handlers.ready;
+      handlers.ready = false;
+      var url = "http://localhost:16006/rest/articles/de305d54-75b4-431b-adb2-eb6b9e546014";
+      request.get(url, function(err, res) {
+        assert(!err);
+        assert.strictEqual(res.statusCode, 503, "Expecting 503 SERVICE UNAVAILABLE");
+        handlers.ready = savedHandlersReady;
+        done();
+      });
+    });
+
+  });
+
+  before(function() {
+    jsonApiTestServer.start();
+  });
+  after(function() {
+    jsonApiTestServer.close();
+  });
+});


### PR DESCRIPTION
Handlers will probably take a bit to set-up and be ready to process requests. Also they might be temporarily unavailable. jsonapi-server should handle these cases gracefully.