### PR TITLE
Foreign query validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,3 +36,5 @@
 2015-11-11 - v0.12.2
 2015-11-12 - Handlers readiness check
 2015-11-12 - v0.13.0
+2015-11-17 - Additional error handling for foreign relation lookup
+2015-11-17 - v0.13.1

--- a/lib/routes/search.js
+++ b/lib/routes/search.js
@@ -24,6 +24,32 @@ searchRoute.register = function() {
         helper.validate(request.params, resourceConfig.searchParams, callback);
       },
       function(callback) {
+        if (!request.params.relationships) return callback();
+
+        var target = Object.keys(request.params.relationships)[0];
+        var relation = resourceConfig.attributes[target];
+
+        if (!relation || !relation._settings || !(relation._settings.__one || relation._settings.__many)) {
+          return callback({
+            status: "403",
+            code: "EFORBIDDEN",
+            title: "Request validation failed",
+            detail: "Requested relation \"" + target + "\" does not exist on " + request.params.type
+          });
+        }
+
+        if (relation._settings.__as) {
+          return callback({
+            status: "403",
+            code: "EFORBIDDEN",
+            title: "Request validation failed",
+            detail: "Requested relation \"" + target + "\" is a foreign reference and does not exist on " + request.params.type
+          });
+        }
+
+        return callback();
+      },
+      function(callback) {
         resourceConfig.handlers.search(request, callback);
       },
       function(results, callback) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-server",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "A fully featured NodeJS sever implementation of json:api. You provide the resources, we provide the api.",
   "keywords": [
     "jsonapi",

--- a/test/get-:resource.js
+++ b/test/get-:resource.js
@@ -314,7 +314,7 @@ describe("Testing jsonapi-server", function() {
 
     describe("by foreign key", function() {
 
-      it("should find resources by relation", function() {
+      it("should find resources by relation", function(done) {
         var url = "http://localhost:16006/rest/articles/?relationships[photos]=aab14844-97e7-401c-98c8-0bd5ec922d93";
         request.get(url, function(err, res, json) {
           assert.equal(err, null);
@@ -322,36 +322,40 @@ describe("Testing jsonapi-server", function() {
 
           assert.equal(res.statusCode, "200", "Expecting 200 OK");
           assert.equal(json.data.length, 2, "Should be 2 matching resources");
+          done();
         });
       });
 
-      it("should error with incorrectly named relations", function() {
+      it("should error with incorrectly named relations", function(done) {
         var url = "http://localhost:16006/rest/articles/?relationships[photo]=aab14844-97e7-401c-98c8-0bd5ec922d93";
         request.get(url, function(err, res, json) {
           assert.equal(err, null);
           json = helpers.validateError(json);
 
           assert.equal(res.statusCode, "403", "Expecting 403 EFORBIDDEN");
+          done();
         });
       });
 
-      it("should error when queriying with non-relation attributes", function() {
+      it("should error when queriying with non-relation attributes", function(done) {
         var url = "http://localhost:16006/rest/articles/?relationships[content]=aab14844-97e7-401c-98c8-0bd5ec922d93";
         request.get(url, function(err, res, json) {
           assert.equal(err, null);
           json = helpers.validateError(json);
 
           assert.equal(res.statusCode, "403", "Expecting 403 EFORBIDDEN");
+          done();
         });
       });
 
-      it("should error when querying the foreign end of a relationship", function() {
+      it("should error when querying the foreign end of a relationship", function(done) {
         var url = "http://localhost:16006/rest/comments/?relationships[article]=aab14844-97e7-401c-98c8-0bd5ec922d93";
         request.get(url, function(err, res, json) {
           assert.equal(err, null);
           json = helpers.validateError(json);
 
           assert.equal(res.statusCode, "403", "Expecting 403 EFORBIDDEN");
+          done();
         });
       });
 

--- a/test/get-:resource.js
+++ b/test/get-:resource.js
@@ -311,6 +311,54 @@ describe("Testing jsonapi-server", function() {
         });
       });
     });
+
+    describe("by foreign key", function() {
+
+      it("should find resources by relation", function() {
+        var url = "http://localhost:16006/rest/articles/?relationships[photos]=aab14844-97e7-401c-98c8-0bd5ec922d93";
+        request.get(url, function(err, res, json) {
+          assert.equal(err, null);
+          json = helpers.validateJson(json);
+
+          assert.equal(res.statusCode, "200", "Expecting 200 OK");
+          assert.equal(json.data.length, 2, "Should be 2 matching resources");
+        });
+      });
+
+      it("should find resources by relation", function() {
+        var url = "http://localhost:16006/rest/articles/?relationships[photo]=aab14844-97e7-401c-98c8-0bd5ec922d93";
+        request.get(url, function(err, res, json) {
+          assert.equal(err, null);
+          json = helpers.validateError(json);
+
+          assert.equal(res.statusCode, "403", "Expecting 403 EFORBIDDEN");
+          assert.equal(json.data.length, 2, "Should be 2 matching resources");
+        });
+      });
+
+      it("should find resources by relation", function() {
+        var url = "http://localhost:16006/rest/articles/?relationships[content]=aab14844-97e7-401c-98c8-0bd5ec922d93";
+        request.get(url, function(err, res, json) {
+          assert.equal(err, null);
+          json = helpers.validateError(json);
+
+          assert.equal(res.statusCode, "403", "Expecting 403 EFORBIDDEN");
+          assert.equal(json.data.length, 2, "Should be 2 matching resources");
+        });
+      });
+
+      it("should find resources by relation", function() {
+        var url = "http://localhost:16006/rest/comments/?relationships[article]=aab14844-97e7-401c-98c8-0bd5ec922d93";
+        request.get(url, function(err, res, json) {
+          assert.equal(err, null);
+          json = helpers.validateError(json);
+
+          assert.equal(res.statusCode, "403", "Expecting 403 EFORBIDDEN");
+          assert.equal(json.data.length, 2, "Should be 2 matching resources");
+        });
+      });
+
+    })
   });
 
   before(function() {

--- a/test/get-:resource.js
+++ b/test/get-:resource.js
@@ -325,36 +325,33 @@ describe("Testing jsonapi-server", function() {
         });
       });
 
-      it("should find resources by relation", function() {
+      it("should error with incorrectly named relations", function() {
         var url = "http://localhost:16006/rest/articles/?relationships[photo]=aab14844-97e7-401c-98c8-0bd5ec922d93";
         request.get(url, function(err, res, json) {
           assert.equal(err, null);
           json = helpers.validateError(json);
 
           assert.equal(res.statusCode, "403", "Expecting 403 EFORBIDDEN");
-          assert.equal(json.data.length, 2, "Should be 2 matching resources");
         });
       });
 
-      it("should find resources by relation", function() {
+      it("should error when queriying with non-relation attributes", function() {
         var url = "http://localhost:16006/rest/articles/?relationships[content]=aab14844-97e7-401c-98c8-0bd5ec922d93";
         request.get(url, function(err, res, json) {
           assert.equal(err, null);
           json = helpers.validateError(json);
 
           assert.equal(res.statusCode, "403", "Expecting 403 EFORBIDDEN");
-          assert.equal(json.data.length, 2, "Should be 2 matching resources");
         });
       });
 
-      it("should find resources by relation", function() {
+      it("should error when querying the foreign end of a relationship", function() {
         var url = "http://localhost:16006/rest/comments/?relationships[article]=aab14844-97e7-401c-98c8-0bd5ec922d93";
         request.get(url, function(err, res, json) {
           assert.equal(err, null);
           json = helpers.validateError(json);
 
           assert.equal(res.statusCode, "403", "Expecting 403 EFORBIDDEN");
-          assert.equal(json.data.length, 2, "Should be 2 matching resources");
         });
       });
 

--- a/test/get-:resource.js
+++ b/test/get-:resource.js
@@ -358,7 +358,7 @@ describe("Testing jsonapi-server", function() {
         });
       });
 
-    })
+    });
   });
 
   before(function() {


### PR DESCRIPTION
This prevents some erroneous queries from getting as far as resource handlers, for example:

This should function correctly and result in 2x resources:
http://localhost:16006/rest/articles/?relationships[photos]=aab14844-97e7-401c-98c8-0bd5ec922d93

These three queries are invalid and should give sensible errors:

http://localhost:16006/rest/articles/?relationships[photo]=aab14844-97e7-401c-98c8-0bd5ec922d93
`403 - "Requested relation "photo" does not exist on articles"`

http://localhost:16006/rest/articles/?relationships[content]=aab14844-97e7-401c-98c8-0bd5ec922d93
`403 - "Requested relation "content" does not exist on articles"`

http://localhost:16006/rest/comments/?relationships[article]=aab14844-97e7-401c-98c8-0bd5ec922d93
`403 - "Requested relation "article" is a foreign reference and does not exist on comments"`