### PR TITLE
Add missed documentation for handlers as objects.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,3 +42,5 @@
 2015-11-17 - v0.14.0
 2015-11-18 - Rename MockHandler to MemoryHandler
 2015-11-18 - v0.15.0
+2015-11-18 - Updated documentation
+2015-11-18 - v0.15.1

--- a/documentation/handlers.md
+++ b/documentation/handlers.md
@@ -1,9 +1,10 @@
 ### Creating Custom Handlers
 
-Handlers represent the mechanism that backs a resource. Each handler is expected to provide:
+Handlers represent the mechanism that backs a resource. Each handler is an object expected to provide:
 
+* a constructor with an option parameter that can be used to inject any required handler specific configuration.
 * a `ready` property indicating the handler is ready to process requests.
-* some of the following functions:
+* some of the following methods:
  * `initialise` - when jsonapi-server loads, this is invoked once for every resource using this handler. Its an opportunity to allocate memory, connect to databases, etc.
  * `search` - for searching for resources that match some vague parameters.
  * `find` - for finding a specific resource by id.
@@ -66,6 +67,10 @@ All errors should be provided in the following format:
   detail: "There is no "+request.params.type+" with id "+request.params.id
 }
 ```
+
+#### constructor
+
+The handler object constructor can, depending on the handler's requirements, expect a object parameter which will contain any properties required for configuring the handler. For example if the handler uses a database for persistence the configuration object will contain the properties required to connect to the database.
 
 #### ready
 

--- a/lib/MemoryHandler.js
+++ b/lib/MemoryHandler.js
@@ -7,8 +7,6 @@ var MemoryStore = module.exports = function MemoryStore() {
 // resources represents out in-memory data store
 var resources = { };
 
-
-
 /**
   Handlers readiness status. This should be set to `true` once all handlers are ready to process requests.
  */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-server",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "A fully featured NodeJS sever implementation of json:api. You provide the resources, we provide the api.",
   "keywords": [
     "jsonapi",


### PR DESCRIPTION
The previous PR that converted handlers to be objects had an accompanying documentation that was missed. This is it!

* [x] :+1: 
* [x] :shipit: 