### PR TITLE
Handler enforcer

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 
 - [Configuring jsonapi-server](documentation/configuring.md)
 - [Defining Resources](documentation/resources.md)
+- [Debugging](documentation/debugging.md)
 - [Foreign Key Relations](documentation/foreign-relations.md)
 - [Creating Handlers](documentation/handlers.md)
 - [Post Processing Examples](documentation/post-processing.md)

--- a/documentation/debugging.md
+++ b/documentation/debugging.md
@@ -1,0 +1,20 @@
+
+### Debugging
+
+Debug output is provided by the [debug](https://www.npmjs.com/package/debug) module.
+
+The supported namespaces are:
+
+ - jsonApi:handler:search
+ - jsonApi:handler:find
+ - jsonApi:handler:create
+ - jsonApi:handler:delete
+ - jsonApi:handler:update
+
+To view the debugging output, provide a comma separated list (or wildcarded via `*`) of namespaces in the `DEBUG` environment variable, for example:
+```
+$ DEBUG=jsonApi:handler:find npm test
+```
+```
+$ DEBUG=jsonApi:handler:* npm test
+```

--- a/lib/handlerEnforcer.js
+++ b/lib/handlerEnforcer.js
@@ -18,7 +18,6 @@ handlerEnforcer._search = function(handlers) {
   };
 };
 
-
 handlerEnforcer._find = function(handlers) {
   var original = handlers.find;
   return function(request, callback) {

--- a/lib/handlerEnforcer.js
+++ b/lib/handlerEnforcer.js
@@ -1,6 +1,15 @@
 "use strict";
 var handlerEnforcer = module.exports = { };
 
+var debug = require("debug");
+var debugging = {
+  search: debug("jsonApi:handler:search"),
+  find: debug("jsonApi:handler:find"),
+  create: debug("jsonApi:handler:create"),
+  update: debug("jsonApi:handler:update"),
+  delete: debug("jsonApi:handler:delete")
+};
+
 handlerEnforcer.wrap = function(handlers) {
   handlers.search = handlerEnforcer._search(handlers);
   handlers.find = handlerEnforcer._find(handlers);
@@ -13,6 +22,7 @@ handlerEnforcer._search = function(handlers) {
   var original = handlers.search;
   return function(request, callback) {
     original.call(handlers, request, function(err, resources) {
+      debugging.search(JSON.stringify(request.params), JSON.stringify(err), JSON.stringify(resources));
       return callback(err, resources);
     });
   };
@@ -22,7 +32,8 @@ handlerEnforcer._find = function(handlers) {
   var original = handlers.find;
   return function(request, callback) {
     original.call(handlers, request, function(err, resource) {
-     return callback(err, resource);
+      debugging.find(JSON.stringify(request.params), JSON.stringify(err), JSON.stringify(resource));
+      return callback(err, resource);
     });
   };
 };
@@ -31,6 +42,7 @@ handlerEnforcer._create = function(handlers) {
   var original = handlers.create;
   return function(request, newResource, callback) {
     original.call(handlers, request, newResource, function(err, handledResource) {
+      debugging.create(JSON.stringify(request.params), JSON.stringify(newResource), JSON.stringify(err), JSON.stringify(handledResource));
       return callback(err, handledResource);
     });
   };
@@ -40,6 +52,7 @@ handlerEnforcer._update = function(handlers) {
   var original = handlers.update;
   return function(request, partialResource, callback) {
     original.call(handlers, request, partialResource, function(err, modifiedResource) {
+      debugging.update(JSON.stringify(request.params), JSON.stringify(partialResource), JSON.stringify(err), JSON.stringify(modifiedResource));
       return callback(err, modifiedResource);
     });
   };
@@ -49,6 +62,7 @@ handlerEnforcer._delete = function(handlers) {
   var original = handlers.delete;
   return function(request, callback) {
     original.call(handlers, request, function(err) {
+      debugging.delete(JSON.stringify(request.params), JSON.stringify(err));
       return callback(err);
     });
   };

--- a/lib/handlerEnforcer.js
+++ b/lib/handlerEnforcer.js
@@ -1,0 +1,56 @@
+"use strict";
+var handlerEnforcer = module.exports = { };
+
+handlerEnforcer.wrap = function(handlers) {
+  handlers.search = handlerEnforcer._search(handlers);
+  handlers.find = handlerEnforcer._find(handlers);
+  handlers.create = handlerEnforcer._create(handlers);
+  handlers.update = handlerEnforcer._update(handlers);
+  handlers.delete = handlerEnforcer._delete(handlers);
+};
+
+handlerEnforcer._search = function(handlers) {
+  var original = handlers.search;
+  return function(request, callback) {
+    original.call(handlers, request, function(err, resources) {
+      return callback(err, resources);
+    });
+  };
+};
+
+
+handlerEnforcer._find = function(handlers) {
+  var original = handlers.find;
+  return function(request, callback) {
+    original.call(handlers, request, function(err, resource) {
+     return callback(err, resource);
+    });
+  };
+};
+
+handlerEnforcer._create = function(handlers) {
+  var original = handlers.create;
+  return function(request, newResource, callback) {
+    original.call(handlers, request, newResource, function(err, handledResource) {
+      return callback(err, handledResource);
+    });
+  };
+};
+
+handlerEnforcer._update = function(handlers) {
+  var original = handlers.update;
+  return function(request, partialResource, callback) {
+    original.call(handlers, request, partialResource, function(err, modifiedResource) {
+      return callback(err, modifiedResource);
+    });
+  };
+};
+
+handlerEnforcer._delete = function(handlers) {
+  var original = handlers.delete;
+  return function(request, callback) {
+    original.call(handlers, request, function(err) {
+      return callback(err);
+    });
+  };
+};

--- a/lib/jsonApi.js
+++ b/lib/jsonApi.js
@@ -7,6 +7,7 @@ var _ = require("underscore");
 var ourJoi = require("./ourJoi.js");
 var router = require("./router.js");
 var responseHelper = require("./responseHelper.js");
+var handlerEnforcer = require("./handlerEnforcer.js");
 var routes = require("./routes");
 var url = require("url");
 
@@ -49,6 +50,8 @@ jsonApi.define = function(resourceConfig) {
   resourceConfig.namespace = resourceConfig.namespace || "default";
   resourceConfig.searchParams = resourceConfig.searchParams || { };
   jsonApi._resources[resourceConfig.resource] = resourceConfig;
+
+  handlerEnforcer.wrap(resourceConfig.handlers);
 
   if (resourceConfig.handlers.initialise) {
     resourceConfig.handlers.initialise(resourceConfig);

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "async": "1.4.2",
     "body-parser": "1.14.0",
     "cookie-parser": "1.4.0",
+    "debug": "2.2.0",
     "express": "4.13.3",
     "joi": "6.7.1",
     "node-uuid": "1.4.3",


### PR DESCRIPTION
This PR enforces the expected parameters and, more importantly, the resulting values provided by custom handler implementations.

@pmcnr-hx this should make it easier to implement your mongoDb handler!

This also includes some debugging via the [debug](https://www.npmjs.com/package/debug) module, with the namespacing follows their recommendation:
```
$ DEBUG=jsonApi:handler:find npm test
```
```
$ DEBUG=jsonApi:handler:* npm test
```