### PR TITLE
Callback with explicit value.

### DIFF
--- a/lib/responseHelper.js
+++ b/lib/responseHelper.js
@@ -32,7 +32,7 @@ responseHelper._enforceSchemaOnObject = function(item, schema, callback) {
   Joi.validate(item, schema, function (err) {
     if (err) {
       console.log("Failed to validate internal object?!", JSON.stringify(arguments));
-      return callback(null);
+      return callback(null, null);
     }
 
     var dataItem = responseHelper._generateDataItem(item, schema);


### PR DESCRIPTION
Callback with an explicit `null` for objects that failed validation to avoid breaking the `async.waterfall` where function is used because of a shorter number of arguments than expected.

* [ ] :cake: 
* [x] :pizza: 