### PR TITLE
Implement top level jsonapi block

### DIFF
--- a/lib/responseHelper.js
+++ b/lib/responseHelper.js
@@ -158,6 +158,9 @@ responseHelper.generateError = function(request, err) {
   if (!(err instanceof Array)) err = [ err ];
 
   var errorResponse = {
+    jsonapi: {
+      version: "1.0"
+    },
     meta: responseHelper._generateMeta(request),
     links: {
       self: responseHelper._baseUrl + request.route.path
@@ -177,6 +180,9 @@ responseHelper.generateError = function(request, err) {
 
 responseHelper._generateResponse = function(request, resourceConfig, sanitisedData) {
   return {
+    jsonapi: {
+      version: "1.0"
+    },
     meta: responseHelper._generateMeta(request),
     links: {
       self: responseHelper._baseUrl + request.route.path + (request.route.query ? ("?" + request.route.query) : "")

--- a/lib/swagger/paths.js
+++ b/lib/swagger/paths.js
@@ -116,8 +116,17 @@ swaggerPaths._getPathOperationObject = function(options) {
         description: options.resourceName + " " + options.handler + " response",
         schema: {
           type: "object",
-          required: [ "meta, links" ],
+          required: [ "jsonapi", "meta, links" ],
           properties: {
+            jsonapi: {
+              type: "object",
+              required: [ "version" ],
+              properties: {
+                version: {
+                  type: "string"
+                }
+              }
+            },
             meta: {
               type: "object"
             },

--- a/lib/swagger/resources.js
+++ b/lib/swagger/resources.js
@@ -139,7 +139,17 @@ swaggerPaths._getResourceDefinition = function(resourceConfig) {
 swaggerPaths._getErrorDefinition = function() {
   return {
     type: "object",
+    required: [ "jsonapi", "meta", "links", "errors" ],
     properties: {
+      jsonapi: {
+        type: "object",
+        required: [ "version" ],
+        properties: {
+          version: {
+            type: "string"
+          }
+        }
+      },
       meta: {
         type: "object"
       },

--- a/test/delete-:resource-:id-relationships-:related.js
+++ b/test/delete-:resource-:id-relationships-:related.js
@@ -96,8 +96,6 @@ describe("Testing jsonapi-server", function() {
           assert.equal(err, null);
           json = helpers.validateJson(json);
 
-          var keys = Object.keys(json);
-          assert.deepEqual(keys, [ "meta", "links", "data" ], "Should have meta, links and data");
           assert.equal(res.statusCode, "200", "Expecting 200");
 
           done();
@@ -113,8 +111,6 @@ describe("Testing jsonapi-server", function() {
           assert.equal(err, null);
           json = helpers.validateJson(json);
 
-          var keys = Object.keys(json);
-          assert.deepEqual(keys, [ "meta", "links", "data" ], "Should have meta, links, data and included");
           assert.equal(res.statusCode, "200", "Expecting 200");
 
           assert.deepEqual(json.data, [

--- a/test/get-:resource.js
+++ b/test/get-:resource.js
@@ -29,8 +29,6 @@ describe("Testing jsonapi-server", function() {
         json = helpers.validateJson(json);
 
         assert.equal(res.statusCode, "200", "Expecting 200 OK");
-        var keys = Object.keys(json);
-        assert.deepEqual(keys, [ "meta", "links", "data", "included" ], "Response should have specific properties");
         assert.deepEqual(json.included, [ ], "Response should have no included resources");
         assert.equal(json.data.length, 4, "Response should contain exactly 4 resources");
         json.data.forEach(function(resource) {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -13,7 +13,7 @@ testHelpers.validateError = function(json) {
     throw new Error("Failed to parse response");
   }
   var keys = Object.keys(json);
-  assert.deepEqual(keys, [ "meta", "links", "errors" ], "Errors should have specific properties");
+  assert.deepEqual(keys, [ "jsonapi", "meta", "links", "errors" ], "Errors should have specific properties");
   assert.equal(typeof json.links.self, "string", "Errors should have a \"self\" link");
   assert.ok(json.errors instanceof Array, "errors should be an array");
   json.errors.forEach(function(error) {
@@ -35,16 +35,15 @@ testHelpers.validateJson = function(json) {
     throw new Error("Failed to parse response");
   }
   assert.ok(json instanceof Object, "Response should be an object");
+  assert.ok(json.jsonapi instanceof Object, "Response should have a jsonapi block");
   assert.ok(json.meta instanceof Object, "Response should have a meta block");
   assert.ok(json.links instanceof Object, "Response should have a links block");
+  assert.ok(!(json.errors instanceof Object), "Response should not have any errors");
   assert.equal(typeof json.links.self, "string", "Response should have a \"self\" link");
   return json;
 };
 
 testHelpers.validateRelationship = function(relationship) {
-  var keys = Object.keys(relationship);
-  assert.deepEqual(keys, [ "meta", "links", "data" ], "Relationships should have specific properties");
-
   assert.ok(relationship.meta instanceof Object, "Relationships should have a meta block");
   assert.equal(typeof relationship.meta.relation, "string", "Relationships should have a relation type");
   assert.ok([ "primary", "foreign" ].indexOf(relationship.meta.relation) > -1, "Relationships must be primary or foreign");

--- a/test/patch-:resource-:id-relationships-:related.js
+++ b/test/patch-:resource-:id-relationships-:related.js
@@ -76,8 +76,6 @@ describe("Testing jsonapi-server", function() {
           assert.equal(err, null);
           json = helpers.validateJson(json);
 
-          var keys = Object.keys(json);
-          assert.deepEqual(keys, [ "meta", "links", "data" ], "Should have meta, links and data");
           assert.equal(res.statusCode, "200", "Expecting 200");
 
           done();
@@ -93,8 +91,6 @@ describe("Testing jsonapi-server", function() {
           assert.equal(err, null);
           json = helpers.validateJson(json);
 
-          var keys = Object.keys(json);
-          assert.deepEqual(keys, [ "meta", "links", "data" ], "Should have meta, links, data and included");
           assert.equal(res.statusCode, "200", "Expecting 200");
 
           assert.deepEqual(json.data, {

--- a/test/patch-:resource-:id.js
+++ b/test/patch-:resource-:id.js
@@ -170,8 +170,6 @@ describe("Testing jsonapi-server", function() {
         assert.equal(err, null);
         json = helpers.validateJson(json);
 
-        var keys = Object.keys(json);
-        assert.deepEqual(keys, [ "meta", "links", "data" ], "Should have meta, links and data");
         assert.equal(res.statusCode, "200", "Expecting 200");
 
         done();
@@ -206,8 +204,6 @@ describe("Testing jsonapi-server", function() {
           assert.equal(err, null);
           json = helpers.validateJson(json);
 
-          var keys = Object.keys(json);
-          assert.deepEqual(keys, [ "meta", "links", "data" ], "Should have meta, links and data");
           assert.equal(res.statusCode, "200", "Expecting 200");
 
           done();
@@ -223,8 +219,6 @@ describe("Testing jsonapi-server", function() {
           assert.equal(err, null);
           json = helpers.validateJson(json);
 
-          var keys = Object.keys(json);
-          assert.deepEqual(keys, [ "meta", "links", "data", "included" ], "Should have meta, links, data and included");
           assert.equal(res.statusCode, "200", "Expecting 200");
 
           assert.deepEqual(json.data, {
@@ -302,8 +296,6 @@ describe("Testing jsonapi-server", function() {
           assert.equal(err, null);
           json = helpers.validateJson(json);
 
-          var keys = Object.keys(json);
-          assert.deepEqual(keys, [ "meta", "links", "data" ], "Should have meta, links and data");
           assert.equal(res.statusCode, "200", "Expecting 200");
 
           done();
@@ -319,8 +311,6 @@ describe("Testing jsonapi-server", function() {
           assert.equal(err, null);
           json = helpers.validateJson(json);
 
-          var keys = Object.keys(json);
-          assert.deepEqual(keys, [ "meta", "links", "data", "included" ], "Should have meta, links, data and included");
           assert.equal(res.statusCode, "200", "Expecting 200");
 
           assert.deepEqual(json.data, {

--- a/test/post-:resource-:id-relationships-:related.js
+++ b/test/post-:resource-:id-relationships-:related.js
@@ -76,8 +76,6 @@ describe("Testing jsonapi-server", function() {
           assert.equal(err, null);
           json = helpers.validateJson(json);
 
-          var keys = Object.keys(json);
-          assert.deepEqual(keys, [ "meta", "links", "data" ], "Should have meta, links and data");
           assert.equal(res.statusCode, "201", "Expecting 201");
 
           done();
@@ -93,8 +91,6 @@ describe("Testing jsonapi-server", function() {
           assert.equal(err, null);
           json = helpers.validateJson(json);
 
-          var keys = Object.keys(json);
-          assert.deepEqual(keys, [ "meta", "links", "data" ], "Should have meta, links, data and included");
           assert.equal(res.statusCode, "200", "Expecting 200");
 
           assert.deepEqual(json.data, [


### PR DESCRIPTION
This PR adds the top  level `jsonapi` block, containing the json:api version to which the api complies with.

 * Add `jsonapi` block to all valid responses.
 * Add `jsonapi` block to all errors.
 * Update the swagger documentation to include the new `jsonapi` block.
 * Update the tests to check for the new `jsonapi` block and removal of some unnecessary assertions.