### PR TITLE
Enable filtering on resource id

### DIFF
--- a/documentation/debugging.md
+++ b/documentation/debugging.md
@@ -13,6 +13,7 @@ The supported namespaces are:
  - jsonApi:validation:input
  - jsonApi:validation:output
  - jsonApi:include
+ - jsonApi:filter
  - jsonApi:errors
 
 

--- a/lib/debugging.js
+++ b/lib/debugging.js
@@ -8,6 +8,7 @@ module.exports = {
     delete: require("debug")("jsonApi:handler:delete")
   },
   include: require("debug")("jsonApi:include"),
+  filter: require("debug")("jsonApi:filter"),
   validationInput: require("debug")("jsonApi:validation:input"),
   validationOutput: require("debug")("jsonApi:validation:output"),
   errors: require("debug")("jsonApi:errors")

--- a/lib/postProcessing/filter.js
+++ b/lib/postProcessing/filter.js
@@ -1,6 +1,8 @@
 "use strict";
 var filter = module.exports = { };
 
+var debug = require("../debugging.js");
+
 filter.action = function(request, response, callback) {
   var allFilters = request.params.filter;
   if (!allFilters) return callback();
@@ -26,12 +28,14 @@ filter.action = function(request, response, callback) {
   if (response.data instanceof Array) {
     for (var j = 0; j < response.data.length; j++) {
       if (!filter._filterKeepObject(response.data[j], filters)) {
+        debug.filter("removed", filters, JSON.stringify(response.data[j].attributes));
         response.data.splice(j, 1);
         j--;
       }
     }
   } else if (response.data instanceof Object) {
     if (!filter._filterKeepObject(response.data, filters)) {
+      debug.filter("removed", filters, JSON.stringify(response.data.attributes));
       response.data = null;
     }
   }
@@ -59,6 +63,7 @@ filter._filterKeepObject = function(someObject, filters) {
   for (var k in filters) {
     var whitelist = filters[k].split(",");
     var propertyText = (someObject.attributes[k] || "");
+    if (k === "id") propertyText = someObject.id;
     var matchOR = false;
     for (var j = 0; j < whitelist.length; j++) {
       var textToMatch = whitelist[j];

--- a/test/get-:resource.js
+++ b/test/get-:resource.js
@@ -172,7 +172,7 @@ describe("Testing jsonapi-server", function() {
       });
 
       it("allows filtering by id", function(done) {
-        var url = "http://localhost:16006/rest/articles?filter[id]=1be0913c-3c25-4261-98f1-e41174025ed5,de305d54-75b4-431b-adb2-eb6b9e546014";
+        var url = "http://localhost:16006/rest/articles?filter[id]=1be0913c-3c25-4261-98f1-e41174025ed5&filter[id]=de305d54-75b4-431b-adb2-eb6b9e546014";
         helpers.request({
           method: "GET",
           url: url

--- a/test/get-:resource.js
+++ b/test/get-:resource.js
@@ -170,6 +170,22 @@ describe("Testing jsonapi-server", function() {
           done();
         });
       });
+
+      it("allows filtering by id", function(done) {
+        var url = "http://localhost:16006/rest/articles?filter[id]=1be0913c-3c25-4261-98f1-e41174025ed5,de305d54-75b4-431b-adb2-eb6b9e546014";
+        helpers.request({
+          method: "GET",
+          url: url
+        }, function(err, res, json) {
+          assert.equal(err, null);
+          json = helpers.validateJson(json);
+
+          assert.equal(res.statusCode, "200", "Expecting 200 OK");
+          assert.equal(json.data.length, 2, "Should only give the 2x requested resources");
+
+          done();
+        });
+      });
     });
 
     describe("applying fields", function() {


### PR DESCRIPTION
This PR allows us to query for several resources, by ID, in one request via the `filter` param. This will allow us to make some great performance improvements for complex inclusions.

http://localhost:16006/rest/articles?filter[id]=1be0913c-3c25-4261-98f1-e41174025ed5&filter[id]=de305d54-75b4-431b-adb2-eb6b9e546014

This also adds some an extra debugging flag to identify which resources get dropped by the jsonapi-server filter sweep:
```javascript
$ DEBUG=jsonApi:filter npm test
...
      applying filter
        ✓ unknown attribute should error
  jsonApi:filter removed +80ms { title: '<M' } {"title":"NodeJS Best Practices","content":"na"}
  jsonApi:filter removed +0ms { title: '<M' } {"title":"Tea for Beginners","content":"na"}
        ✓ less than
  jsonApi:filter removed +11ms { title: '>M' } {"title":"Linux Rocks","content":"na"}
  jsonApi:filter removed +0ms { title: '>M' } {"title":"How to AWS","content":"na"}
        ✓ greater than
  jsonApi:filter removed +8ms { title: '~linux rocks' } {"title":"NodeJS Best Practices","content":"na"}
```