### PR TITLE
Enable multiple foreign key lookups in one request

### DIFF
--- a/lib/MemoryHandler.js
+++ b/lib/MemoryHandler.js
@@ -22,20 +22,22 @@ MemoryStore.prototype.initialise = function(resourceConfig) {
 };
 
 /**
-  Search for a list of resources, give a resource type.
+  Search for a list of resources, given a resource type.
  */
 MemoryStore.prototype.search = function(request, callback) {
   // If a relationships param is passed in, filter against those relations
   if (request.params.relationships) {
     var mustMatch = request.params.relationships;
     var matches = resources[request.params.type].filter(function(anyResource) {
-      var match = true;
+      var match = false;
       Object.keys(mustMatch).forEach(function(i) {
         var fKeys = anyResource[i];
+        var target = mustMatch[i];
+        if (!(target instanceof Array)) target = [ target ];
         if (!(fKeys instanceof Array)) fKeys = [ fKeys ];
         fKeys = fKeys.map(function(j) { return j.id; });
-        if (fKeys.indexOf(mustMatch[i]) === -1) {
-          match = false;
+        if (_.intersection(fKeys, target).length > 0) {
+          match = true;
         }
       });
       return match;

--- a/test/get-:resource.js
+++ b/test/get-:resource.js
@@ -383,7 +383,7 @@ describe("Testing jsonapi-server", function() {
 
     describe("by foreign key", function() {
 
-      it("should find resources by relation", function(done) {
+      it("should find resources by a relation", function(done) {
         var url = "http://localhost:16006/rest/articles/?relationships[photos]=aab14844-97e7-401c-98c8-0bd5ec922d93";
         helpers.request({
           method: "GET",
@@ -394,6 +394,21 @@ describe("Testing jsonapi-server", function() {
 
           assert.equal(res.statusCode, "200", "Expecting 200 OK");
           assert.equal(json.data.length, 2, "Should be 2 matching resources");
+          done();
+        });
+      });
+
+      it("should find resources by many relations", function(done) {
+        var url = "http://localhost:16006/rest/articles/?relationships[photos]=aab14844-97e7-401c-98c8-0bd5ec922d93&relationships[photos]=4a8acd65-78bb-4020-b9eb-2d058a86a2a0";
+        helpers.request({
+          method: "GET",
+          url: url
+        }, function(err, res, json) {
+          assert.equal(err, null);
+          json = helpers.validateJson(json);
+
+          assert.equal(res.statusCode, "200", "Expecting 200 OK");
+          assert.equal(json.data.length, 3, "Should be 3 matching resources");
           done();
         });
       });


### PR DESCRIPTION
This PR allows us to query for several resources, by foreign ID, in one request via the filter param. This behaviour was implemented incorrectly in the stock MemoryHandler. This will allow us to make some great performance improvements for complex inclusions.

Find me all articles who reference these 2x photos:
http://localhost:16006/rest/articles/?relationships[photos]=aab14844-97e7-401c-98c8-0bd5ec922d93&relationships[photos]=4a8acd65-78bb-4020-b9eb-2d058a86a2a0