### PR TITLE
More efficient inclusions

### DIFF
--- a/documentation/debugging.md
+++ b/documentation/debugging.md
@@ -15,6 +15,7 @@ The supported namespaces are:
  - jsonApi:include
  - jsonApi:filter
  - jsonApi:errors
+ - jsonApi:requestCounter
 
 
 To view the debugging output, provide a comma separated list (or wildcarded via `*`) of namespaces in the `DEBUG` environment variable, for example:

--- a/lib/debugging.js
+++ b/lib/debugging.js
@@ -11,5 +11,6 @@ module.exports = {
   filter: require("debug")("jsonApi:filter"),
   validationInput: require("debug")("jsonApi:validation:input"),
   validationOutput: require("debug")("jsonApi:validation:output"),
-  errors: require("debug")("jsonApi:errors")
+  errors: require("debug")("jsonApi:errors"),
+  requestCounter: require("debug")("jsonApi:requestCounter")
 };

--- a/lib/postProcess.js
+++ b/lib/postProcess.js
@@ -2,6 +2,7 @@
 var postProcess = module.exports = { };
 
 var jsonApi = require("..");
+var debug = require("./debugging.js");
 var _ = require("underscore");
 var externalRequest = require("request").defaults({
   pool: { maxSockets: Infinity }
@@ -37,10 +38,22 @@ postProcess._fetchRelatedResources = function(request, mainResource, callback) {
   var dataItems = mainResource[request.params.relation];
   if (!(dataItems instanceof Array)) dataItems = [ dataItems ];
 
-  var resourcesToFetch = dataItems.map(function(dataItem) {
-    return jsonApi._apiConfig.pathPrefix + dataItem.type + "/" + dataItem.id;
+  var resourcesToFetch = dataItems.reduce(function(map, dataItem) {
+    map[dataItem.type] = map[dataItem.type] || [ ];
+    map[dataItem.type].push(dataItem.id);
+    return map;
+  }, { });
+
+  resourcesToFetch = Object.keys(resourcesToFetch).map(function(type) {
+    var ids = resourcesToFetch[type];
+    var urlJoiner = "&filter[id]=";
+    ids = urlJoiner + ids.join(urlJoiner);
+    return jsonApi._apiConfig.pathPrefix + type + "/?" + ids;
   });
+
   async.map(resourcesToFetch, function(related, done) {
+    debug.include(related);
+
     externalRequest({
       method: "GET",
       uri: related,

--- a/lib/postProcessing/include.js
+++ b/lib/postProcessing/include.js
@@ -111,35 +111,75 @@ includePP._fillIncludeTree = function(includeTree, request, callback) {
   ****/
   var includes = Object.keys(includeTree);
 
-  var resourcesToFetch = includeTree._dataItems.map(function(dataItem) {
+  var map = {
+    primary: { },
+    foreign: { }
+  };
+  includeTree._dataItems.forEach(function(dataItem) {
     if (!dataItem) return [ ];
     return Object.keys(dataItem.relationships || { }).filter(function(keyName) {
       return (keyName[0] !== "_") && (includes.indexOf(keyName) !== -1);
-    }).map(function(keyName) {
-      var url = dataItem.relationships[keyName].links.related;
-      if (url.indexOf("?") === -1) url += "?";
-      if (includeTree[keyName]._filter) {
-        url += "&" + includeTree[keyName]._filter.join("&");
+    }).forEach(function(relation) {
+      var someRelation = dataItem.relationships[relation];
+
+      if (someRelation.meta.relation === "primary") {
+        var relationItems = someRelation.data;
+        if (!(relationItems instanceof Array)) relationItems = [ relationItems ];
+        relationItems.forEach(function(relationItem) {
+          var key = relationItem.type + "~~" + relation;
+          map.primary[key] = map.primary[key] || [ ];
+          map.primary[key].push(relationItem.id);
+        });
       }
-      return keyName + "~~" + url;
+
+      if (someRelation.meta.relation === "foreign") {
+        var key = someRelation.meta.as + "~~" + someRelation.meta.belongsTo;
+        map.foreign[key] = map.foreign[key] || [ ];
+        map.foreign[key].push(dataItem.id);
+      }
     });
   });
 
-  resourcesToFetch = [].concat.apply([], resourcesToFetch);
-  resourcesToFetch = _.unique(resourcesToFetch);
+  var resourcesToFetch = [];
+
+  Object.keys(map.primary).forEach(function(relation) {
+    var ids = _.unique(map.primary[relation]);
+    var parts = relation.split("~~");
+    var urlJoiner = "&filter[id]=";
+    ids = urlJoiner + ids.join(urlJoiner);
+    if (includeTree[parts[1]]._filter) {
+      ids += "&" + includeTree[parts[1]]._filter.join("&");
+    }
+    resourcesToFetch.push({
+      url: jsonApi._apiConfig.pathPrefix + parts[0] + "/?" + ids,
+      as: relation
+    });
+  });
+
+  Object.keys(map.foreign).forEach(function(relation) {
+    var ids = _.unique(map.foreign[relation]);
+    var parts = relation.split("~~");
+    var urlJoiner = "&relationships[" + parts[0] + "]=";
+    ids = urlJoiner + ids.join(urlJoiner);
+    if (includeTree[parts[1]]._filter) {
+      ids += "&" + includeTree[parts[1]]._filter.join("&");
+    }
+    resourcesToFetch.push({
+      url: jsonApi._apiConfig.pathPrefix + parts[1] + "/?" + ids,
+      as: relation
+    });
+  });
 
   async.map(resourcesToFetch, function(related, done) {
-    var parts = related.split("~~");
-    var type = parts[0];
-    var link = parts[1];
-
-    debug.include(link);
+    var parts = related.as.split("~~");
+    debug.include(related);
 
     externalRequest({
       method: "GET",
-      uri: link,
+      uri: related.url,
       headers: request.safeHeaders
     }, function(err, res, json) {
+      // console.log(err, json)
       if (err || !json) {
         return done(null);
       }
@@ -159,7 +199,7 @@ includePP._fillIncludeTree = function(includeTree, request, callback) {
       var data = json.data;
       if (!data) return done();
       if (!(data instanceof Array)) data = [ data ];
-      includeTree[type]._dataItems = includeTree[type]._dataItems.concat(data);
+      includeTree[parts[1]]._dataItems = includeTree[parts[1]]._dataItems.concat(data);
       return done();
     });
   }, function(err) {

--- a/lib/router.js
+++ b/lib/router.js
@@ -8,6 +8,7 @@ var server;
 var bodyParser = require("body-parser");
 var cookieParser = require("cookie-parser");
 var jsonApi = require("./jsonApi.js");
+var debug = require("./debugging.js");
 var url = require("url");
 
 app.use(function(req, res, next) {
@@ -48,13 +49,12 @@ app.use(cookieParser());
 app.disable("x-powered-by");
 app.disable("etag");
 
-// var requestId = 0;
-// app.route("*").all(function(req, res, next) {
-//   req.query.requestId = requestId;
-//   console.log(requestId, "===", req.url);
-//   requestId++;
-//   next();
-// });
+var requestId = 0;
+app.route("*").all(function(req, res, next) {
+  debug.requestCounter(requestId++, req.url);
+  if (requestId > 1000) requestId = 0;
+  next();
+});
 
 router.listen = function(port) {
   if (!server) {


### PR DESCRIPTION
I've had a go at heavily optimising the postProcessing inclusion module. This PR is a work-in-progress, it needs a serious refactor, but the performance is there. Instead of blindly following `related` links to glue together a complex inclusion, `jsonapi-server` now groups id's together and makes custom search requests to reduce the load on the server:

Before:
```
http://localhost:16006/rest/articles/d850ea75-4427-4f81-8595-039990aeede5/author?& +0ms
http://localhost:16006/rest/articles/d850ea75-4427-4f81-8595-039990aeede5/photos?& +1ms
http://localhost:16006/rest/articles/fa2a073f-8c64-4cbb-9158-b8f67a4ab9f5/author?& +0ms
http://localhost:16006/rest/articles/fa2a073f-8c64-4cbb-9158-b8f67a4ab9f5/photos?& +0ms
http://localhost:16006/rest/photos/?relationships[photographer]=cc5cca2e-0dd8-4b95-8cfc-a11230e73116& +39ms
http://localhost:16006/rest/photos/?relationships[photographer]=d850ea75-4427-4f81-8595-039990aeede5& +0ms
http://localhost:16006/rest/photos/?relationships[photographer]=32fb0105-acaa-4adb-9ec4-8b49633695e1& +1ms
http://localhost:16006/rest/photos/?relationships[photographer]=ad3aa89e-9c5b-4ac9-a652-6670f9f27587& +0ms
```

After:
```
http://localhost:16006/rest/people/?&filter[id]=cc5cca2e-0dd8-4b95-8cfc-a11230e73116&filter[id]=d850ea75-4427-4f81-8595-039990aeede5&filter[id]=32fb0105-acaa-4adb-9ec4-8b49633695e1&filter[id]=ad3aa89e-9c5b-4ac9-a652-6670f9f27587
http://localhost:16006/rest/photos/?&relationships[photographer]=cc5cca2e-0dd8-4b95-8cfc-a11230e73116&relationships[photographer]=32fb0105-acaa-4adb-9ec4-8b49633695e1&relationships[photographer]=d850ea75-4427-4f81-8595-039990aeede5&relationships[photographer]=ad3aa89e-9c5b-4ac9-a652-6670f9f27587
```

Here's the performance in master right now. The test server responds to 155 requests for data and the test suite passes in 860ms:
```
/repos/jsonapi-server$ npm test
  ...
  Testing jsonapi-server
    Searching for resources
      applying includes
        ✓ unknown attribute should error
        ✓ include author (31ms)
        ✓ include author and photos (67ms)
        ✓ include author.photos and photos (55ms)
        ✓ include author.photos (39ms)
        ✓ include author.photos with filter (29ms)
  ...
  jsonApi:requestCounter 155 +8ms /rest/photos/dfb689d7-3899-4e1d-a0bf-30298ebac6da

  86 passing (860ms)
```
And here's the performance in this branch. The test server responds to 99 requests for data and the test suite passes in 755ms:
```
/repos/jsonapi-server$ npm test
  ...
  Testing jsonapi-server
    Searching for resources
      applying includes
        ✓ unknown attribute should error
        ✓ include author (14ms)
        ✓ include author and photos (25ms)
        ✓ include author.photos and photos (32ms)
        ✓ include author.photos (30ms)
        ✓ include author.photos with filter (18ms)
  ...
  jsonApi:requestCounter 99 +8ms /rest/photos/dfb689d7-3899-4e1d-a0bf-30298ebac6da
  
  86 passing (755ms)
```

There's a new debug helper, `DEBUG=jsonApi:requestCounter` to help identify requests.
