### PR TITLE
Remove the relationships param

### DIFF
--- a/documentation/foreign-relations.md
+++ b/documentation/foreign-relations.md
@@ -174,7 +174,7 @@ relationships: {
       // get information about the linkage - list of ids and types
       self: "http://localhost:16006/rest/articles/relationships/?comments=6b017640-827c-4d50-8dcc-79d766abb408",
       // get full details of all linked resources (perform a search against the foreign key)
-      related: "http://localhost:16006/rest/articles/?relationships[comments]=6b017640-827c-4d50-8dcc-79d766abb408"
+      related: "http://localhost:16006/rest/articles/?filter[comments]=6b017640-827c-4d50-8dcc-79d766abb408"
     }
   }
 }

--- a/lib/MemoryHandler.js
+++ b/lib/MemoryHandler.js
@@ -26,37 +26,10 @@ MemoryStore.prototype.initialise = function(resourceConfig) {
  */
 MemoryStore.prototype.search = function(request, callback) {
   var self = this;
-  var resultCount = 0;
 
-  // If a relationships param is passed in, filter against those relations
-  if (request.params.relationships) {
-    var mustMatch = request.params.relationships;
-    var matches = resources[request.params.type].filter(function(anyResource) {
-      var match = false;
-      Object.keys(mustMatch).forEach(function(i) {
-        var fKeys = anyResource[i];
-        var target = mustMatch[i];
-        if (!(target instanceof Array)) target = [ target ];
-        if (!(fKeys instanceof Array)) fKeys = [ fKeys ];
-        fKeys = fKeys.map(function(j) { return j.id; });
-        if (_.intersection(fKeys, target).length > 0) {
-          match = true;
-        }
-      });
-      return match;
-    });
-    self._sortList(request, matches);
-    resultCount = matches.length;
-    if (request.params.page) {
-      matches = matches.slice(request.params.page.offset, request.params.page.offset + request.params.page.limit);
-    }
-    return callback(null, matches, resultCount);
-  }
-
-  // No specific search params are supported, so return ALL resources of the requested type
   var results = [].concat(resources[request.params.type]);
   self._sortList(request, results);
-  resultCount = results.length;
+  var resultCount = results.length;
   if (request.params.page) {
     results = results.slice(request.params.page.offset, request.params.page.offset + request.params.page.limit);
   }

--- a/lib/jsonApi.js
+++ b/lib/jsonApi.js
@@ -79,9 +79,6 @@ jsonApi.define = function(resourceConfig) {
       .example("title"),
     include: ourJoi.Joi.any()
       .description("An attribute to include")
-      .example("title"),
-    relationships: ourJoi.Joi.any()
-      .description("An attribute to include")
       .example("title")
   }, resourceConfig.searchParams, pagination.joiPageDefinition);
 

--- a/lib/postProcessing/filter.js
+++ b/lib/postProcessing/filter.js
@@ -1,10 +1,11 @@
 "use strict";
 var filter = module.exports = { };
 
+var _ = require("underscore");
 var debug = require("../debugging.js");
 
 filter.action = function(request, response, callback) {
-  var allFilters = request.params.filter;
+  var allFilters = _.extend({ }, request.params.filter);
   if (!allFilters) return callback();
 
   var filters = { };

--- a/lib/postProcessing/filter.js
+++ b/lib/postProcessing/filter.js
@@ -62,14 +62,50 @@ filter._filterMatches = function(textToMatch, propertyText) {
 filter._filterKeepObject = function(someObject, filters) {
   for (var k in filters) {
     var whitelist = filters[k].split(",");
-    var propertyText = (someObject.attributes[k] || "");
-    if (k === "id") propertyText = someObject.id;
-    var matchOR = false;
-    for (var j = 0; j < whitelist.length; j++) {
-      var textToMatch = whitelist[j];
-      if (filter._filterMatches(textToMatch, propertyText)) matchOR = true;
+
+    if (someObject.attributes.hasOwnProperty(k) || (k === "id")) {
+      var attributeValue = someObject.attributes[k] || "";
+      if (k === "id") attributeValue = someObject.id;
+      var attributeMatches = filter._attributesMatchesOR(attributeValue, whitelist);
+      if (!attributeMatches) return false;
     }
-    if (!matchOR) return false;
+
+    if (someObject.relationships.hasOwnProperty(k)) {
+      var relationships = someObject.relationships[k] || "";
+      var relationshipMatches = filter._relationshipMatchesOR(relationships, whitelist);
+      if (!relationshipMatches) return false;
+    }
   }
   return true;
+};
+
+filter._attributesMatchesOR = function(attributeValue, whitelist) {
+  var matchOR = false;
+  for (var j = 0; j < whitelist.length; j++) {
+    var textToMatch = whitelist[j];
+    if (filter._filterMatches(textToMatch, attributeValue)) {
+      matchOR = true;
+    }
+  }
+  return matchOR;
+};
+
+filter._relationshipMatchesOR = function(relationships, whitelist) {
+  var matchOR = false;
+
+  var data = relationships.data;
+  if (!data) return false;
+
+  if (!(data instanceof Array)) data = [ data ];
+  data = data.map(function(relation) {
+    return relation.id;
+  });
+
+  for (var j = 0; j < whitelist.length; j++) {
+    var textToMatch = whitelist[j];
+    if (data.indexOf(textToMatch) !== -1) {
+      matchOR = true;
+    }
+  }
+  return matchOR;
 };

--- a/lib/postProcessing/filter.js
+++ b/lib/postProcessing/filter.js
@@ -82,12 +82,11 @@ filter._filterKeepObject = function(someObject, filters) {
 
 filter._attributesMatchesOR = function(attributeValue, whitelist) {
   var matchOR = false;
-  for (var j = 0; j < whitelist.length; j++) {
-    var textToMatch = whitelist[j];
+  whitelist.forEach(function(textToMatch) {
     if (filter._filterMatches(textToMatch, attributeValue)) {
       matchOR = true;
     }
-  }
+  });
   return matchOR;
 };
 
@@ -102,11 +101,10 @@ filter._relationshipMatchesOR = function(relationships, whitelist) {
     return relation.id;
   });
 
-  for (var j = 0; j < whitelist.length; j++) {
-    var textToMatch = whitelist[j];
+  whitelist.forEach(function(textToMatch) {
     if (data.indexOf(textToMatch) !== -1) {
       matchOR = true;
     }
-  }
+  });
   return matchOR;
 };

--- a/lib/postProcessing/filter.js
+++ b/lib/postProcessing/filter.js
@@ -60,18 +60,18 @@ filter._filterMatches = function(textToMatch, propertyText) {
 };
 
 filter._filterKeepObject = function(someObject, filters) {
-  for (var k in filters) {
-    var whitelist = filters[k].split(",");
+  for (var filterName in filters) {
+    var whitelist = filters[filterName].split(",");
 
-    if (someObject.attributes.hasOwnProperty(k) || (k === "id")) {
-      var attributeValue = someObject.attributes[k] || "";
-      if (k === "id") attributeValue = someObject.id;
+    if (someObject.attributes.hasOwnProperty(filterName) || (filterName === "id")) {
+      var attributeValue = someObject.attributes[filterName] || "";
+      if (filterName === "id") attributeValue = someObject.id;
       var attributeMatches = filter._attributesMatchesOR(attributeValue, whitelist);
       if (!attributeMatches) return false;
     }
 
-    if (someObject.relationships.hasOwnProperty(k)) {
-      var relationships = someObject.relationships[k] || "";
+    if (someObject.relationships.hasOwnProperty(filterName)) {
+      var relationships = someObject.relationships[filterName] || "";
       var relationshipMatches = filter._relationshipMatchesOR(relationships, whitelist);
       if (!relationshipMatches) return false;
     }

--- a/lib/postProcessing/include.js
+++ b/lib/postProcessing/include.js
@@ -68,6 +68,12 @@ includePP._arrayToTree = function(request, includes, filters, callback) {
     }
 
     filter = filter[first] || { };
+    if (filter instanceof Array) {
+      filter = filter.filter(function(i) {
+        return i instanceof Object;
+      }).pop();
+    }
+
     if (!node[first]) {
       node[first] = {
         _dataItems: [ ],
@@ -75,9 +81,11 @@ includePP._arrayToTree = function(request, includes, filters, callback) {
         _filter: [ ]
       };
 
-      for (var i in filter) {
-        if (!(typeof filter[i] === "string" || (filter[i] instanceof Array))) continue;
-        node[first]._filter.push("filter[" + i + "]=" + filter[i]);
+      if (!((filter instanceof Array) && (filter.length === 0))) {
+        for (var i in filter) {
+          if (!(typeof filter[i] === "string" || (filter[i] instanceof Array))) continue;
+          node[first]._filter.push("filter[" + i + "]=" + filter[i]);
+        }
       }
     }
     iterate(rest, node[first], filter);

--- a/lib/postProcessing/include.js
+++ b/lib/postProcessing/include.js
@@ -159,7 +159,7 @@ includePP._fillIncludeTree = function(includeTree, request, callback) {
   Object.keys(map.foreign).forEach(function(relation) {
     var ids = _.unique(map.foreign[relation]);
     var parts = relation.split("~~");
-    var urlJoiner = "&relationships[" + parts[0] + "]=";
+    var urlJoiner = "&filter[" + parts[0] + "]=";
     ids = urlJoiner + ids.join(urlJoiner);
     if (includeTree[parts[1]]._filter) {
       ids += "&" + includeTree[parts[1]]._filter.join("&");

--- a/lib/responseHelper.js
+++ b/lib/responseHelper.js
@@ -137,8 +137,8 @@ responseHelper._generateLink = function(item, schemaProperty, linkProperty) {
     // /rest/bookings/relationships/?customer=26aa8a92-2845-4e40-999f-1fa006ec8c63
     link.links.self = responseHelper._baseUrl + relatedResource + "/relationships/?" + schemaProperty._settings.__as + "=" + item.id;
     // get full details of all linked resources
-    // /rest/bookings/?relationships[customer]=26aa8a92-2845-4e40-999f-1fa006ec8c63
-    link.links.related = responseHelper._baseUrl + relatedResource + "/?relationships[" + schemaProperty._settings.__as + "]=" + item.id;
+    // /rest/bookings/?filter[customer]=26aa8a92-2845-4e40-999f-1fa006ec8c63
+    link.links.related = responseHelper._baseUrl + relatedResource + "/?filter[" + schemaProperty._settings.__as + "]=" + item.id;
     if (!item[linkProperty]) {
       link.data = undefined;
     }

--- a/lib/routes/search.js
+++ b/lib/routes/search.js
@@ -26,11 +26,10 @@ searchRoute.register = function() {
         helper.validate(request.params, resourceConfig.searchParams, callback);
       },
       function validateFilterParams(callback) {
-        var allFilters = request.params.filter;
-        if (!allFilters) return callback();
+        if (!request.params.filter) return callback();
 
-        var filters = { };
-        for (var i in allFilters) {
+        for (var i in request.params.filter) {
+          if (request.params.filter[i] instanceof Object) continue;
           if (!request.resourceConfig.attributes[i]) {
             return callback({
               status: "403",
@@ -48,13 +47,8 @@ searchRoute.register = function() {
               detail: "Requested relation \"" + i + "\" is a foreign reference and does not exist on " + request.params.type
             });
           }
-          if (allFilters[i] instanceof Array) {
-            allFilters[i] = allFilters[i].join(",").split(",");
-          }
-          filters[i] = allFilters[i];
         }
 
-        request.params.filter = filters;
         return callback();
       },
       function validatePaginationParams(callback) {

--- a/lib/routes/search.js
+++ b/lib/routes/search.js
@@ -25,32 +25,6 @@ searchRoute.register = function() {
       function(callback) {
         helper.validate(request.params, resourceConfig.searchParams, callback);
       },
-      function validationRelationshipParams(callback) {
-        if (!request.params.relationships) return callback();
-
-        var target = Object.keys(request.params.relationships)[0];
-        var relation = resourceConfig.attributes[target];
-
-        if (!relation || !relation._settings || !(relation._settings.__one || relation._settings.__many)) {
-          return callback({
-            status: "403",
-            code: "EFORBIDDEN",
-            title: "Request validation failed",
-            detail: "Requested relation \"" + target + "\" does not exist on " + request.params.type
-          });
-        }
-
-        if (relation._settings.__as) {
-          return callback({
-            status: "403",
-            code: "EFORBIDDEN",
-            title: "Request validation failed",
-            detail: "Requested relation \"" + target + "\" is a foreign reference and does not exist on " + request.params.type
-          });
-        }
-
-        return callback();
-      },
       function validateFilterParams(callback) {
         var allFilters = request.params.filter;
         if (!allFilters) return callback();
@@ -63,6 +37,15 @@ searchRoute.register = function() {
               code: "EFORBIDDEN",
               title: "Invalid filter",
               detail: request.resourceConfig.resource + " do not have property " + i
+            });
+          }
+          var relationSettings = request.resourceConfig.attributes[i]._settings;
+          if (relationSettings && relationSettings.__as) {
+            return callback({
+              status: "403",
+              code: "EFORBIDDEN",
+              title: "Request validation failed",
+              detail: "Requested relation \"" + i + "\" is a foreign reference and does not exist on " + request.params.type
             });
           }
           if (allFilters[i] instanceof Array) {

--- a/test/get-resource.js
+++ b/test/get-resource.js
@@ -186,6 +186,23 @@ describe("Testing jsonapi-server", function() {
           done();
         });
       });
+
+      it("allows deep filtering", function(done) {
+        var url = "http://localhost:16006/rest/articles?include=author&filter[author]=d850ea75-4427-4f81-8595-039990aeede5&filter[author][firstname]=Mark";
+        helpers.request({
+          method: "GET",
+          url: url
+        }, function(err, res, json) {
+          assert.equal(err, null);
+          json = helpers.validateJson(json);
+
+          assert.equal(res.statusCode, "200", "Expecting 200 OK");
+          assert.equal(json.data.length, 1, "Should give the one matching resource");
+          assert.equal(json.included.length, 1, "Should give the one matching include");
+
+          done();
+        });
+      });
     });
 
     describe("applying fields", function() {

--- a/test/get-resource.js
+++ b/test/get-resource.js
@@ -384,7 +384,7 @@ describe("Testing jsonapi-server", function() {
     describe("by foreign key", function() {
 
       it("should find resources by a relation", function(done) {
-        var url = "http://localhost:16006/rest/articles/?relationships[photos]=aab14844-97e7-401c-98c8-0bd5ec922d93";
+        var url = "http://localhost:16006/rest/articles/?filter[photos]=aab14844-97e7-401c-98c8-0bd5ec922d93";
         helpers.request({
           method: "GET",
           url: url
@@ -399,7 +399,7 @@ describe("Testing jsonapi-server", function() {
       });
 
       it("should find resources by many relations", function(done) {
-        var url = "http://localhost:16006/rest/articles/?relationships[photos]=aab14844-97e7-401c-98c8-0bd5ec922d93&relationships[photos]=4a8acd65-78bb-4020-b9eb-2d058a86a2a0";
+        var url = "http://localhost:16006/rest/articles/?filter[photos]=aab14844-97e7-401c-98c8-0bd5ec922d93&filter[photos]=4a8acd65-78bb-4020-b9eb-2d058a86a2a0";
         helpers.request({
           method: "GET",
           url: url
@@ -414,21 +414,7 @@ describe("Testing jsonapi-server", function() {
       });
 
       it("should error with incorrectly named relations", function(done) {
-        var url = "http://localhost:16006/rest/articles/?relationships[photo]=aab14844-97e7-401c-98c8-0bd5ec922d93";
-        helpers.request({
-          method: "GET",
-          url: url
-        }, function(err, res, json) {
-          assert.equal(err, null);
-          json = helpers.validateError(json);
-
-          assert.equal(res.statusCode, "403", "Expecting 403 EFORBIDDEN");
-          done();
-        });
-      });
-
-      it("should error when queriying with non-relation attributes", function(done) {
-        var url = "http://localhost:16006/rest/articles/?relationships[content]=aab14844-97e7-401c-98c8-0bd5ec922d93";
+        var url = "http://localhost:16006/rest/articles/?filter[photo]=aab14844-97e7-401c-98c8-0bd5ec922d93";
         helpers.request({
           method: "GET",
           url: url
@@ -442,7 +428,7 @@ describe("Testing jsonapi-server", function() {
       });
 
       it("should error when querying the foreign end of a relationship", function(done) {
-        var url = "http://localhost:16006/rest/comments/?relationships[article]=aab14844-97e7-401c-98c8-0bd5ec922d93";
+        var url = "http://localhost:16006/rest/comments/?filter[article]=aab14844-97e7-401c-98c8-0bd5ec922d93";
         helpers.request({
           method: "GET",
           url: url

--- a/test/patch-resource-id.js
+++ b/test/patch-resource-id.js
@@ -256,7 +256,7 @@ describe("Testing jsonapi-server", function() {
                 },
                 "links": {
                   "self": "http://localhost:16006/rest/articles/relationships/?comments=3f1a89c2-eb85-4799-a048-6735db24b7eb",
-                  "related": "http://localhost:16006/rest/articles/?relationships[comments]=3f1a89c2-eb85-4799-a048-6735db24b7eb"
+                  "related": "http://localhost:16006/rest/articles/?filter[comments]=3f1a89c2-eb85-4799-a048-6735db24b7eb"
                 }
               }
             },
@@ -345,7 +345,7 @@ describe("Testing jsonapi-server", function() {
                 },
                 "links": {
                   "self": "http://localhost:16006/rest/articles/relationships/?comments=3f1a89c2-eb85-4799-a048-6735db24b7eb",
-                  "related": "http://localhost:16006/rest/articles/?relationships[comments]=3f1a89c2-eb85-4799-a048-6735db24b7eb"
+                  "related": "http://localhost:16006/rest/articles/?filter[comments]=3f1a89c2-eb85-4799-a048-6735db24b7eb"
                 }
               }
             },


### PR DESCRIPTION
This addresses #64 - stop namespacing the filtering of relationships into a `relationships` query parameter and merge that functionality into the `filter` query parameter.