### PR TITLE
Automatic CPU profiling over test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 coverage.html
 complexity
 npm-debug.log
+jsonapi-server.cpuprofile

--- a/lib/postProcess.js
+++ b/lib/postProcess.js
@@ -3,7 +3,6 @@ var postProcess = module.exports = { };
 
 var jsonApi = require("..");
 var debug = require("./debugging.js");
-var _ = require("underscore");
 var externalRequest = require("request").defaults({
   pool: { maxSockets: Infinity }
 });
@@ -87,14 +86,12 @@ postProcess.fetchForeignKeys = function(request, items, schema, callback) {
     items = [ items ];
   }
   items.forEach(function(item) {
-    Object.keys(schema).map(function(i) {
-      return _.extend({ name: i }, schema[i]);
-    }).filter(function(schemaProperty) {
-      var settings = schemaProperty._settings;
-      return settings && settings.__as;
-    }).forEach(function(schemaProperty) {
-      item[schemaProperty.name] = undefined;
-    });
+    for (var i in schema) {
+      var settings = schema[i]._settings;
+      if (settings && settings.__as) {
+        item[i] = undefined;
+      }
+    }
   });
   return callback();
 };

--- a/package.json
+++ b/package.json
@@ -25,11 +25,9 @@
     "debug": "2.2.0",
     "express": "4.13.3",
     "joi": "6.7.1",
-    "node-inspector": "0.12.5",
     "node-uuid": "1.4.3",
     "request": "2.63.0",
-    "underscore": "1.8.3",
-    "v8-profiler": "5.5.0"
+    "underscore": "1.8.3"
   },
   "devDependencies": {
     "mocha": "2.2.5",
@@ -38,7 +36,9 @@
     "mocha-lcov-reporter": "0.0.2",
     "coveralls": "2.11.2",
     "plato": "1.5.0",
-    "mocha-performance": "0.1.0"
+    "mocha-performance": "0.1.0",
+    "v8-profiler": "5.5.0",
+    "node-inspector": "0.12.5"
   },
   "scripts": {
     "test": "node ./node_modules/mocha/bin/mocha -R spec ./test/*.js",

--- a/package.json
+++ b/package.json
@@ -25,9 +25,11 @@
     "debug": "2.2.0",
     "express": "4.13.3",
     "joi": "6.7.1",
+    "node-inspector": "0.12.5",
     "node-uuid": "1.4.3",
     "request": "2.63.0",
-    "underscore": "1.8.3"
+    "underscore": "1.8.3",
+    "v8-profiler": "5.5.0"
   },
   "devDependencies": {
     "mocha": "2.2.5",

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -4,6 +4,18 @@ var testHelpers = module.exports = { };
 var assert = require("assert");
 var request = require("request");
 var swaggerValidator = require("./swaggerValidator.js");
+var profiler = require("v8-profiler");
+var fs = require("fs");
+
+before(function() {
+  profiler.startProfiling("", true);
+});
+
+after(function(done) {
+  var profile = profiler.stopProfiling("");
+  fs.writeFileSync("jsonapi-server.cpuprofile", JSON.stringify(profile));
+  setTimeout(done, 1000 * 1000 * 1000);
+});
 
 testHelpers.validateError = function(json) {
   try {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -6,6 +6,7 @@ var request = require("request");
 var swaggerValidator = require("./swaggerValidator.js");
 var profiler = require("v8-profiler");
 var fs = require("fs");
+var path = require("path");
 
 before(function() {
   profiler.startProfiling("", true);
@@ -13,8 +14,11 @@ before(function() {
 
 after(function(done) {
   var profile = profiler.stopProfiling("");
-  fs.writeFileSync("jsonapi-server.cpuprofile", JSON.stringify(profile));
-  setTimeout(done, 1000 * 1000 * 1000);
+  var profileFileName = "jsonapi-server.cpuprofile";
+  var filePath = path.join(__dirname, "..", profileFileName);
+  fs.writeFileSync(filePath, JSON.stringify(profile));
+  console.error("Saved CPU profile to", filePath);
+  done();
 });
 
 testHelpers.validateError = function(json) {


### PR DESCRIPTION
You'll need to be using a recent version of NodeJS for this to work!

Whenever we run the test suite, it'll automatically run a CPU profile and output it to `./jsonapi-server.cpuprofile`

If you start up `node-inspector` via `$ ./node_modules/.bin/node-inspector`, click on the "Profiles" tab, click the "Load" button and select the previously mentioned cpu profile file. You'll be able to see the profiling data in all its glory!