### PR TITLE
Adding a complex recursive relationship

### DIFF
--- a/example/resources/articles.js
+++ b/example/resources/articles.js
@@ -73,7 +73,7 @@ jsonApi.define({
       content: "na",
       author: { type: "people", id: "32fb0105-acaa-4adb-9ec4-8b49633695e1" },
       tags: [
-        { type: "tags", id: "7541a4de-4986-4597-81b9-cf31b6762486" }
+        { type: "tags", id: "8d196606-134c-4504-a93a-0d372f78d6c5" }
       ],
       photos: [
         { type: "photos", id: "aab14844-97e7-401c-98c8-0bd5ec922d93" }

--- a/example/resources/tags.js
+++ b/example/resources/tags.js
@@ -13,23 +13,43 @@ jsonApi.define({
     articles: jsonApi.Joi.belongsToMany({
       resource: "articles",
       as: "tags"
+    }),
+    parent: jsonApi.Joi.one("tags"),
+    children: jsonApi.Joi.belongsToMany({
+      resource: "tags",
+      as: "parent"
     })
   },
   examples: [
     {
       id: "7541a4de-4986-4597-81b9-cf31b6762486",
       type: "tags",
-      name: "live"
+      name: "live",
+      parent: { type: "tags", id: "2a3bdea4-a889-480d-b886-104498c86f69" }
     },
     {
       id: "2a3bdea4-a889-480d-b886-104498c86f69",
       type: "tags",
-      name: "staging"
+      name: "staging",
+      parent: { type: "tags", id: "6ec62f6d-9f82-40c5-b4f4-279ed1765492" }
     },
     {
       id: "6ec62f6d-9f82-40c5-b4f4-279ed1765492",
       type: "tags",
-      name: "needs-work"
+      name: "building",
+      parent: { type: "tags", id: "68538177-7a62-4752-bc4e-8f971d253b42" }
+    },
+    {
+      id: "68538177-7a62-4752-bc4e-8f971d253b42",
+      type: "tags",
+      name: "development",
+      parent: { type: "tags", id: "8d196606-134c-4504-a93a-0d372f78d6c5" }
+    },
+    {
+      id: "8d196606-134c-4504-a93a-0d372f78d6c5",
+      type: "tags",
+      name: "planning",
+      parent: null
     }
   ]
 });

--- a/lib/postProcessing/include.js
+++ b/lib/postProcessing/include.js
@@ -132,16 +132,17 @@ includePP._fillIncludeTree = function(includeTree, request, callback) {
 
       if (someRelation.meta.relation === "primary") {
         var relationItems = someRelation.data;
+        if (!relationItems) return;
         if (!(relationItems instanceof Array)) relationItems = [ relationItems ];
         relationItems.forEach(function(relationItem) {
-          var key = relationItem.type + "~~" + relation;
+          var key = relationItem.type + "~~" + relation + "~~" + relation;
           map.primary[key] = map.primary[key] || [ ];
           map.primary[key].push(relationItem.id);
         });
       }
 
       if (someRelation.meta.relation === "foreign") {
-        var key = someRelation.meta.as + "~~" + someRelation.meta.belongsTo;
+        var key = someRelation.meta.as + "~~" + someRelation.meta.belongsTo + "~~" + relation;
         map.foreign[key] = map.foreign[key] || [ ];
         map.foreign[key].push(dataItem.id);
       }
@@ -169,8 +170,8 @@ includePP._fillIncludeTree = function(includeTree, request, callback) {
     var parts = relation.split("~~");
     var urlJoiner = "&filter[" + parts[0] + "]=";
     ids = urlJoiner + ids.join(urlJoiner);
-    if (includeTree[parts[1]]._filter) {
-      ids += "&" + includeTree[parts[1]]._filter.join("&");
+    if (includeTree[parts[2]]._filter) {
+      ids += "&" + includeTree[parts[2]]._filter.join("&");
     }
     resourcesToFetch.push({
       url: jsonApi._apiConfig.pathPrefix + parts[1] + "/?" + ids,
@@ -207,7 +208,7 @@ includePP._fillIncludeTree = function(includeTree, request, callback) {
       var data = json.data;
       if (!data) return done();
       if (!(data instanceof Array)) data = [ data ];
-      includeTree[parts[1]]._dataItems = includeTree[parts[1]]._dataItems.concat(data);
+      includeTree[parts[2]]._dataItems = includeTree[parts[2]]._dataItems.concat(data);
       return done();
     });
   }, function(err) {

--- a/test/get-resource-id.js
+++ b/test/get-resource-id.js
@@ -70,24 +70,59 @@ describe("Testing jsonapi-server", function() {
       });
     });
 
-    it("with includes", function(done) {
-      var url = "http://localhost:16006/rest/articles/de305d54-75b4-431b-adb2-eb6b9e546014?include=author";
-      helpers.request({
-        method: "GET",
-        url: url
-      }, function(err, res, json) {
-        assert.equal(err, null);
-        json = helpers.validateJson(json);
+    describe("with includes", function() {
+      it("basic include", function(done) {
+        var url = "http://localhost:16006/rest/articles/de305d54-75b4-431b-adb2-eb6b9e546014?include=author";
+        helpers.request({
+          method: "GET",
+          url: url
+        }, function(err, res, json) {
+          assert.equal(err, null);
+          json = helpers.validateJson(json);
 
-        assert.equal(res.statusCode, "200", "Expecting 200 OK");
-        assert.equal(json.included.length, 1, "Should be 1 included resource");
+          assert.equal(res.statusCode, "200", "Expecting 200 OK");
+          assert.equal(json.included.length, 1, "Should be 1 included resource");
 
-        var people = json.included.filter(function(resource) {
-          return resource.type === "people";
+          var people = json.included.filter(function(resource) {
+            return resource.type === "people";
+          });
+          assert.equal(people.length, 1, "Should be 1 included people resource");
+
+          done();
         });
-        assert.equal(people.length, 1, "Should be 1 included people resource");
+      });
 
-        done();
+      it("including over a null relation", function(done) {
+        var url = "http://localhost:16006/rest/tags/8d196606-134c-4504-a93a-0d372f78d6c5?include=parent";
+        helpers.request({
+          method: "GET",
+          url: url
+        }, function(err, res, json) {
+          assert.equal(err, null);
+          json = helpers.validateJson(json);
+
+          assert.equal(res.statusCode, "200", "Expecting 200 OK");
+          assert.equal(json.included.length, 0, "Should be 0 included resources");
+          done();
+        });
+      });
+    });
+
+    describe("with recursive includes", function() {
+      it("works with a manually expanded string", function(done) {
+        var url = "http://localhost:16006/rest/tags/7541a4de-4986-4597-81b9-cf31b6762486?include=parent.parent.parent.parent.articles";
+        helpers.request({
+          method: "GET",
+          url: url
+        }, function(err, res, json) {
+          assert.equal(err, null);
+          json = helpers.validateJson(json);
+
+          assert.equal(res.statusCode, "200", "Expecting 200 OK");
+          assert.equal(json.included.length, 5, "Should be 5 included resources");
+          assert.equal(json.included[4].type, "articles", "Last include should be an article");
+          done();
+        });
       });
     });
   });


### PR DESCRIPTION
This adds a nice recursive relationship between all tags.

It also fixes two bugs - one around having a resource include itself via a differently named attribute, and one around attempting to include across a relationship whose value is `null`/`undefined`.

I've added some tests to prove inclusions work in the above scenarios.