### PR TITLE
v1.0.3 - Fixing some regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,3 +63,6 @@
 2015-12-10 - v1.0.1
 2015-12-11 - Test harness improvements
 2015-12-11 - v1.0.2
+2015-12-17 - Don't pass on content-length HTTP headers on inclusion requests
+2015-12-17 - Filter won't match undefined properties anymore
+2015-12-17 - v1.0.3

--- a/lib/postProcessing/filter.js
+++ b/lib/postProcessing/filter.js
@@ -71,12 +71,12 @@ filter._filterKeepObject = function(someObject, filters) {
       if (filterName === "id") attributeValue = someObject.id;
       var attributeMatches = filter._attributesMatchesOR(attributeValue, whitelist);
       if (!attributeMatches) return false;
-    }
-
-    if (someObject.relationships.hasOwnProperty(filterName)) {
+    } else if (someObject.relationships.hasOwnProperty(filterName)) {
       var relationships = someObject.relationships[filterName] || "";
       var relationshipMatches = filter._relationshipMatchesOR(relationships, whitelist);
       if (!relationshipMatches) return false;
+    } else {
+      return false;
     }
   }
   return true;

--- a/lib/router.js
+++ b/lib/router.js
@@ -118,7 +118,7 @@ router._getParams = function(req) {
   urlParts = urlParts.join("").split("?");
 
   var headersToRemove = [
-    "host", "connection", "accept-encoding", "accept-language"
+    "host", "connection", "accept-encoding", "accept-language", "content-length"
   ];
 
   return {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-server",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A fully featured NodeJS sever implementation of json:api. You provide the resources, we provide the api.",
   "keywords": [
     "jsonapi",


### PR DESCRIPTION
After revisiting https://github.com/holidayextras/jsonapi-client, bumping the version of `jsonapi-server` and running the test suite, we identified two minor regressions:

1. `Content-Length` headers shouldn't be forwarded on for inclusion requests
2. Resources with undefined properties shouldn't match using the stock filtering functionality.

In the future I'd like to find a way of running dependent projects against new releases to identify these edge cases before each new release. I'd also like to write some extensive unit tests, but I don't think it's a good use of my time right now.

You can test this by checking out jsonapi-client, updating to the latest jsonapi-server release (v1.0.2) and running npm-test. Update to this version and the tests will pass.