### PR TITLE
Enable pathless api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,3 +66,5 @@
 2015-12-17 - Don't pass on content-length HTTP headers on inclusion requests
 2015-12-17 - Filter won't match undefined properties anymore
 2015-12-17 - v1.0.3
+2015-12-30 - Enable path-less API
+2015-12-30 - v1.0.4

--- a/lib/router.js
+++ b/lib/router.js
@@ -115,7 +115,7 @@ router.bindErrorHandler = function(callback) {
 router._getParams = function(req) {
   var urlParts = req.url.split(jsonApi._apiConfig.base);
   urlParts.shift();
-  urlParts = urlParts.join("").split("?");
+  urlParts = urlParts.join(jsonApi._apiConfig.base).split("?");
 
   var headersToRemove = [
     "host", "connection", "accept-encoding", "accept-language", "content-length"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-server",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A fully featured NodeJS sever implementation of json:api. You provide the resources, we provide the api.",
   "keywords": [
     "jsonapi",


### PR DESCRIPTION
This PR enables a user to drop this line from their config:
```
  base: "rest", // A path prefix
```
to serve up an API directly from the hostname.

To see this in action, delete the [base definition](https://github.com/holidayextras/jsonapi-server/blob/master/example/server.js#L26) from the example server, navigate to [http://localhost:16006/articles](http://localhost:16006/articles) and click around, verifying all the links still work.