### PR TITLE
Correctly set the Location header when creating resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,3 +68,5 @@
 2015-12-17 - v1.0.3
 2015-12-30 - Enable path-less API
 2015-12-30 - v1.0.4
+2015-12-31 - Set Location header correctly when creating resources
+2015-12-31 - v1.0.5

--- a/lib/routes/create.js
+++ b/lib/routes/create.js
@@ -59,6 +59,9 @@ createRoute.register = function() {
       },
       function(sanitisedData, callback) {
         request.route.path += "/" + newResource.id;
+        res.set({
+          "Location": request.route.combined + "/" + newResource.id
+        });
         response = responseHelper._generateResponse(request, resourceConfig, sanitisedData);
         postProcess.handle(request, response, callback);
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-server",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "A fully featured NodeJS sever implementation of json:api. You provide the resources, we provide the api.",
   "keywords": [
     "jsonapi",

--- a/test/post-resource.js
+++ b/test/post-resource.js
@@ -139,6 +139,7 @@ describe("Testing jsonapi-server", function() {
           assert.equal(err, null);
           json = helpers.validateJson(json);
 
+          assert.equal(res.headers.location, "http://localhost:16006/rest/photos/" + json.data.id);
           assert.equal(res.statusCode, "201", "Expecting 201");
           assert.equal(json.data.type, "photos", "Should be a people resource");
           helpers.validatePhoto(json.data);


### PR DESCRIPTION
According to the [JSON-API spec. 201 Create](http://jsonapi.org/format/#crud-creating-responses-201)
the response header for create should be:
````
HTTP/1.1 201 Created
Location: http://example.com/photos/008ef600-0cad-4fb5-860a-958414defde7
````

Before this PR, the Location header was `http://example.com/photos`. This work appends the resource ID on the end and adds an assertion to prove it works as-per the spec.