### PR TITLE
Use Jois sanitisation as well as validation for input+output

### DIFF
--- a/example/resources/articles.js
+++ b/example/resources/articles.js
@@ -20,6 +20,9 @@ jsonApi.define({
     created: jsonApi.Joi.date().format("YYYY-MM-DD")
       .description("The date on which the article was created, YYYY-MM-DD")
       .example("2017-05-01"),
+    status: jsonApi.Joi.string().default("published")
+      .description("The status of the article - draft, ready, published")
+      .example("published"),
     author: jsonApi.Joi.one("people")
       .description("The person who wrote the article"),
     tags: jsonApi.Joi.many("tags")

--- a/example/resources/articles.js
+++ b/example/resources/articles.js
@@ -6,9 +6,9 @@ jsonApi.define({
   description: "Represents the core content, people love to read articles.",
   handlers: new jsonApi.MemoryHandler(),
   searchParams: {
-    query: jsonApi.Joi.string()
+    query: jsonApi.Joi.number()
       .description("Fuzzy text match against titles")
-      .example("learn")
+      .example(123)
   },
   attributes: {
     title: jsonApi.Joi.string().required()

--- a/example/resources/comments.js
+++ b/example/resources/comments.js
@@ -10,7 +10,7 @@ jsonApi.define({
     body: jsonApi.Joi.string()
       .description("The tag name")
       .example("Summer"),
-    timestamp: jsonApi.Joi.date().format("YYYY-MM-DD")
+    timestamp: jsonApi.Joi.string().regex(/^[12]\d\d\d-[01]\d-[0123]\d$/)
       .description("The date on which the comment was created, YYYY-MM-DD")
       .example("2017-05-01"),
     author: jsonApi.Joi.one("people")

--- a/lib/responseHelper.js
+++ b/lib/responseHelper.js
@@ -36,13 +36,13 @@ responseHelper._enforceSchemaOnArray = function(items, schema, callback) {
 
 responseHelper._enforceSchemaOnObject = function(item, schema, callback) {
   debug.validationOutput(JSON.stringify(item));
-  Joi.validate(item, schema, function (err) {
+  Joi.validate(item, schema, function (err, sanitisedItem) {
     if (err) {
       debug.validationError(err.message, JSON.stringify(item));
       return callback(null, null);
     }
 
-    var dataItem = responseHelper._generateDataItem(item, schema);
+    var dataItem = responseHelper._generateDataItem(sanitisedItem, schema);
     return callback(null, dataItem);
   });
 };

--- a/lib/routes/helper.js
+++ b/lib/routes/helper.js
@@ -5,11 +5,14 @@ var Joi = require("joi");
 var responseHelper = require("../responseHelper.js");
 var router = require("../router.js");
 var debug = require("../debugging.js");
+var _ = {
+  assign: require("lodash.assign")
+};
 
 
 helper.validate = function(someObject, someDefinition, callback) {
   debug.validationInput(JSON.stringify(someObject));
-  Joi.validate(someObject, someDefinition, function (err) {
+  Joi.validate(someObject, someDefinition, function (err, sanitisedObject) {
     if (err) {
       return callback({
         status: "403",
@@ -18,6 +21,7 @@ helper.validate = function(someObject, someDefinition, callback) {
         detail: err
       });
     }
+    _.assign(someObject, sanitisedObject);
     callback();
   });
 };

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -94,6 +94,7 @@ testHelpers.validateArticle = function(resource) {
   assert.equal(resource.type, "articles", "Resources must have a type of articles");
   assert.equal(typeof resource.attributes.title, "string", "An articles title should be a string");
   assert.equal(typeof resource.attributes.content, "string", "An articles content should be a string");
+  assert.equal(typeof resource.attributes.status, "string", "An articles status should default to, and always be, a string");
   assert.equal(resource.relationships.author.meta.relation, "primary", "An articles author is a primary relation");
   testHelpers.validateRelationship(resource.relationships.author);
   assert.equal(resource.relationships.tags.meta.relation, "primary", "An articles tags are a primary relation");


### PR DESCRIPTION
In the past we've been using Joi to simply validate objects. Joi will also sanitise data, which does some useful things like:

1. Query string properties (which are always interpreted as strings) will be coerced into the correct type - so number types in a query string will become numbers.
2. We can apply default values to both attribute and search parameters.

You can test this by starting the example server with debugging:
```
$ DEBUG=jsonApi:handler:search npm start
```
and visiting http://localhost:16006/rest/articles?query=123

You'll see in the console the type coercion taking place - the `query` param becomes a number:
```
  jsonApi:handler:search {"type":"articles","query":123,"page":{"offset":0,"limit":50}} .......
```

You'll see in the response payload every article has a new attribute `status: "published"` which is added by the new Joi schema `status: jsonApi.Joi.string().default("published")`.