### PR TITLE
Additional usage documentatinon

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A config driven NodeJS framework implementing [`json:api`](http://jsonapi.org/).
 
 ### Motivation / Justification / Rationale
 
-This framework solves the challenge of json:api without coupling us to any one ORM solution. Every other module out there is either tightly coupled to a database implementation, tracking an old version of the json:api spec, or is merely a helper library for a small feature. If you're building an API and your use case only involves reading and writing to a data store... well count yourself lucky. For everyone else, this framework provides the flexibility to provide a complex API without wasting developer time focusing on anything other than shipping valuable features.
+This framework solves the challenge of json:api without coupling us to any one ORM solution. Every other module out there is either tightly coupled to a database implementation, tracking an old version of the json:api spec, or is merely a helper library for a small feature. If you're building an API and your use case only involves reading and writing to a data store... well count yourself lucky. For everyone else, this framework provides the flexibility to provide a complex API without being confined to any one technology.
 
 A config driven approach to building an API enables:
  * Enforced json:api responses

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ We've also written a library to ease the consumption of a json:api compliant ser
 
 ### Full documentation
 
+- [Suggested Project Structure](documentation/suggested-project-structure.md)
 - [Configuring jsonapi-server](documentation/configuring.md)
 - [Automatic Swagger Generation](documentation/swagger.md)
 - [Defining Resources](documentation/resources.md)
@@ -52,6 +53,7 @@ We've also written a library to ease the consumption of a json:api compliant ser
 - [Foreign Key Relations](documentation/foreign-relations.md)
 - [Custom Handlers](documentation/handlers.md)
 - [Post Processing Examples](documentation/post-processing.md)
+- [Migrating from an existing express server](documentation/api-migration.md)
 
 ### The tl;dr
 

--- a/documentation/api-migration.md
+++ b/documentation/api-migration.md
@@ -24,7 +24,7 @@ var bootstrapJsonApi = function(expressApp) {
   // Alter the expressJs constructor to return your existing instance
   // preventing jsonapi-server from trying to build a new one
   require.cache[express].exports = function() {
-    return app;
+    return expressApp;
   };
   // Now load jsonapi-server, which will require express and call The
   // constructor, which now returns your existing express instance

--- a/documentation/api-migration.md
+++ b/documentation/api-migration.md
@@ -1,0 +1,38 @@
+
+### Migrating towards jsonapi-server from ExpressJS
+
+If you've got an existing API powered by ExpressJS and you want to migrate towards using json:api, you're in the right place. The migration process we're running with is to:
+
+1. Get jsonapi-server running alongside an existing express app using a path prefix.
+2. Define some new resources using the in-memory handlers.
+3. Lock in the resource definitions and develop custom handlers to provide data in the new formats by re-using existing functionality in the current codebase.
+4. Migrate traffic over to the json:api resources.
+5. Kill off the old express server.
+
+We're using something similar to the below snippet to run jsonapi-server alongside our existing express application:
+
+```javascript
+// BEFORE you run this function you should bring up your expressJs
+// server as usual, bind your routes, etc etc.
+// Do NOT require() jsonapi-server, this function does it for you!
+// Execute this function with an existing express() instance:
+var bootstrapJsonApi = function(expressApp) {
+  // Find the express module in the NodeJS internal cache
+  var express = Object.keys(require.cache).filter(function(i) {
+    return i.match('/node_modules/express/index.js');
+  }).pop();
+  // Alter the expressJs constructor to return your existing instance
+  // preventing jsonapi-server from trying to build a new one
+  require.cache[express].exports = function() {
+    return app;
+  };
+  // Now load jsonapi-server, which will require express and call The
+  // constructor, which now returns your existing express instance
+  jsonApi = require('jsonapi-server');
+  // Finally make this function call to register the json:api routes
+  require('jsonapi-server/lib/routes/index.js').register();
+
+  // Now define your resources as usual.
+  // DO NOT call jsonApi.start() !!
+};
+```

--- a/documentation/suggested-project-structure.md
+++ b/documentation/suggested-project-structure.md
@@ -64,14 +64,14 @@ jsonApi.define({
 
 #### Example handler
 
-Handlers are like your controllers - they need to, at very least, provide the functionality described in the [handler documentation](handlers.md). The follow example covers how you implement [jsonapi-store-elasticsearch](https://github.com/holidayextras/jsonapi-store-elasticsearch).
+Handlers are like your controllers - they need to, at very least, provide the functionality described in the [handler documentation](handlers.md). The following example covers how you implement [jsonapi-store-elasticsearch](https://github.com/holidayextras/jsonapi-store-elasticsearch).
 
 ```javascript
 var EsHandler = require("jsonapi-store-elasticsearch");
 
 // You might want to pull this out further to share it
 // amongst other handlers
-var specificEsCluster = var new ElasticsearchStore({
+var specificEsCluster = var new EsHandler({
   host: "localhost:9200"
 });
 

--- a/documentation/suggested-project-structure.md
+++ b/documentation/suggested-project-structure.md
@@ -45,7 +45,7 @@ jsonApi.start();
 
 #### Example resource
 
-The idea is to stick to having one resource per file and stick to pure config. Each file should do nothing more than define a resource. Handlers should be referenced from the `../handlers` folder, which enables us to easily abstract functionality by sharing features amongst handlers. Resource files are effectively defining your routing  layer.
+The idea is to stick to having one resource per file and stick to pure config. Each file should do nothing more than define a resource. Handlers should be referenced from the `../handlers` folder, which enables us to easily abstract functionality by sharing features amongst handlers. Resource files are effectively defining your routing layer.
 
 ```javascript
 var commentHandler = require("../handlers/commentHandler.js");
@@ -64,7 +64,7 @@ jsonApi.define({
 
 #### Example handler
 
-Handlers are like your controllers - they need to, are very least, provide the functionality described in the [handler documentation](handlers.md). The follow example covers how you implement [jsonapi-store-elasticsearch](https://github.com/holidayextras/jsonapi-store-elasticsearch).
+Handlers are like your controllers - they need to, at very least, provide the functionality described in the [handler documentation](handlers.md). The follow example covers how you implement [jsonapi-store-elasticsearch](https://github.com/holidayextras/jsonapi-store-elasticsearch).
 
 ```javascript
 var EsHandler = require("jsonapi-store-elasticsearch");

--- a/documentation/suggested-project-structure.md
+++ b/documentation/suggested-project-structure.md
@@ -1,0 +1,97 @@
+### Suggested Project Structure
+
+ * `server.js` is the main entry point.
+ * Think of the `resources` folder as your `routes`.
+ * Think of the `handlers` folder as your `controllers`.
+
+```
+├── handlers
+│   ├── articleHandler.js
+│   ├── commentHandler.js
+│   ├── peopleHandler.js
+│   ├── photoHandler.js
+│   └── tagHandler.js
+├── resources
+│   ├── articles.js
+│   ├── comments.js
+│   ├── people.js
+│   ├── photos.js
+│   └── tags.js
+└── server.js          
+```
+
+#### Example server.js
+
+This is the main entry point for your API. The goal is to configure jsonapi-server and load all the resources.
+
+```javascript
+var jsonApi = require("jsonapi-server");
+var fs = require("fs");
+var path = require("path");
+
+jsonApi.setConfig({
+  // Put your config here!
+});
+
+// Load all the resources
+fs.readdirSync(path.join(__dirname, "/resources")).filter(function(filename) {
+  return /^[a-z].*\.js$/.test(filename);
+}).map(function(filename) {
+  return path.join(__dirname, "/resources/", filename);
+}).forEach(require);
+
+jsonApi.start();
+```
+
+#### Example resource
+
+The idea is to stick to having one resource per file and stick to pure config. Each file should do nothing more than define a resource. Handlers should be referenced from the `../handlers` folder, which enables us to easily abstract functionality by sharing features amongst handlers. Resource files are effectively defining your routing  layer.
+
+```javascript
+var commentHandler = require("../handlers/commentHandler.js");
+
+jsonApi.define({
+  resource: "photos",
+  handlers: memoryHandler,
+  attributes: {
+    title: jsonApi.Joi.string()
+    url: jsonApi.Joi.string().uri()
+    height: jsonApi.Joi.number().min(1).max(10000).precision(0)
+    width: jsonApi.Joi.number().min(1).max(10000).precision(0)
+  }
+});
+```
+
+#### Example handler
+
+Handlers are like your controllers - they need to, are very least, provide the functionality described in the [handler documentation](handlers.md). The follow example covers how you implement [jsonapi-store-elasticsearch](https://github.com/holidayextras/jsonapi-store-elasticsearch).
+
+```javascript
+var EsHandler = require("jsonapi-store-elasticsearch");
+
+// You might want to pull this out further to share it
+// amongst other handlers
+var specificEsCluster = var new ElasticsearchStore({
+  host: "localhost:9200"
+});
+
+module.exports = specificEsCluster;
+
+// // If you want to intercept calls to extend existing behaviour:
+//
+// var baseCreate = specificEsCluster.create;
+// specificEsCluster.create = function(request, callback) {
+//   // tweak something?
+//   baseCreate.call(specificEsCluster, request, function(err, result) {
+//     // tweak something else?
+//     return callback(err, result);
+//   });
+// };
+
+// // If you want to partially override behaviour to
+// // provide a more efficient solution:
+//
+// efficientHandler.search = function(request, callback) {
+//   // do your own thing, invoke the callback when done
+// };
+```

--- a/example/handlers/articleHandler.js
+++ b/example/handlers/articleHandler.js
@@ -1,0 +1,4 @@
+"use strict";
+var jsonApi = require("../..");
+
+module.exports = new jsonApi.MemoryHandler();

--- a/example/handlers/commentHandler.js
+++ b/example/handlers/commentHandler.js
@@ -1,0 +1,4 @@
+"use strict";
+var jsonApi = require("../..");
+
+module.exports = new jsonApi.MemoryHandler();

--- a/example/handlers/peopleHandler.js
+++ b/example/handlers/peopleHandler.js
@@ -1,0 +1,4 @@
+"use strict";
+var jsonApi = require("../..");
+
+module.exports = new jsonApi.MemoryHandler();

--- a/example/handlers/photoHandler.js
+++ b/example/handlers/photoHandler.js
@@ -1,0 +1,4 @@
+"use strict";
+var jsonApi = require("../..");
+
+module.exports = new jsonApi.MemoryHandler();

--- a/example/handlers/tagHandler.js
+++ b/example/handlers/tagHandler.js
@@ -1,0 +1,4 @@
+"use strict";
+var jsonApi = require("../..");
+
+module.exports = new jsonApi.MemoryHandler();

--- a/example/resources/articles.js
+++ b/example/resources/articles.js
@@ -1,10 +1,11 @@
 var jsonApi = require("../../.");
+var articleHandler = require("../handlers/articleHandler.js");
 
 jsonApi.define({
   namespace: "json:api",
   resource: "articles",
   description: "Represents the core content, people love to read articles.",
-  handlers: new jsonApi.MemoryHandler(),
+  handlers: articleHandler,
   searchParams: {
     query: jsonApi.Joi.string()
       .description("Fuzzy text match against titles")

--- a/example/resources/comments.js
+++ b/example/resources/comments.js
@@ -1,10 +1,11 @@
 var jsonApi = require("../../.");
+var commentHandler = require("../handlers/commentHandler.js");
 
 jsonApi.define({
   namespace: "json:api",
   resource: "comments",
   description: "Allow people to attach short messages to articles",
-  handlers: new jsonApi.MemoryHandler(),
+  handlers: commentHandler,
   searchParams: { },
   attributes: {
     body: jsonApi.Joi.string()

--- a/example/resources/people.js
+++ b/example/resources/people.js
@@ -1,10 +1,11 @@
 var jsonApi = require("../../.");
+var peopleHandler = require("../handlers/peopleHandler.js");
 
 jsonApi.define({
   namespace: "json:api",
   resource: "people",
   description: "Used to attribute work to specific people.",
-  handlers: new jsonApi.MemoryHandler(),
+  handlers: peopleHandler,
   searchParams: { },
   attributes: {
     firstname: jsonApi.Joi.string().alphanum()

--- a/example/resources/photos.js
+++ b/example/resources/photos.js
@@ -1,10 +1,11 @@
 var jsonApi = require("../../.");
+var photoHandler = require("../handlers/photoHandler.js");
 
 jsonApi.define({
   namespace: "json:api",
   resource: "photos",
   description: "Used to represent all the images in the system.",
-  handlers: new jsonApi.MemoryHandler(),
+  handlers: photoHandler,
   searchParams: { },
   attributes: {
     title: jsonApi.Joi.string()

--- a/example/resources/tags.js
+++ b/example/resources/tags.js
@@ -1,10 +1,11 @@
 var jsonApi = require("../../.");
+var tagHandler = require("../handlers/tagHandler.js");
 
 jsonApi.define({
   namespace: "json:api",
   resource: "tags",
   description: "Used to group resources together, useful for finding related resources.",
-  handlers: new jsonApi.MemoryHandler(),
+  handlers: tagHandler,
   searchParams: { },
   attributes: {
     name: jsonApi.Joi.string()


### PR DESCRIPTION
I've added some docs around how to migrate from an express-based API to jsonapi-server, plus a suggestion on how to organise a jsonapi-server codebase.