### PR TITLE
Cleanup package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,18 +19,18 @@
     "node": "*"
   },
   "dependencies": {
-    "async": "1.4.2",
-    "body-parser": "1.14.0",
+    "async": "1.5.2",
+    "body-parser": "1.14.2",
     "cookie-parser": "1.4.0",
     "debug": "2.2.0",
     "express": "4.13.3",
-    "joi": "6.7.1",
+    "joi": "6.10.1",
     "lodash.assign": "3.2.0",
     "lodash.omit": "3.1.0",
     "lodash.pick": "3.1.0",
     "lodash.uniq": "3.2.2",
-    "node-uuid": "1.4.3",
-    "request": "2.63.0"
+    "node-uuid": "1.4.7",
+    "request": "2.67.0"
   },
   "devDependencies": {
     "mocha": "2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jsonapi-server",
   "version": "1.0.5",
-  "description": "A fully featured NodeJS sever implementation of json:api. You provide the resources, we provide the api.",
+  "description": "A config driven NodeJS framework implementing json:api",
   "keywords": [
     "jsonapi",
     "json:api",
@@ -30,8 +30,7 @@
     "lodash.pick": "3.1.0",
     "lodash.uniq": "3.2.2",
     "node-uuid": "1.4.3",
-    "request": "2.63.0",
-    "v8-profiler": "5.5.0"
+    "request": "2.63.0"
   },
   "devDependencies": {
     "mocha": "2.2.5",
@@ -41,7 +40,8 @@
     "coveralls": "2.11.2",
     "plato": "1.5.0",
     "mocha-performance": "0.1.0",
-    "node-inspector": "0.12.5"
+    "node-inspector": "0.12.5",
+    "v8-profiler": "5.5.0"
   },
   "scripts": {
     "test": "node ./node_modules/mocha/bin/mocha -S -R spec ./test/*.js",


### PR DESCRIPTION
* Update package description
* Move `v8-profiler` from `dependencies` to `devDependencies` (it's only used by the test suite)