### PR TITLE
Error fast when creating invalid foreign relation

### DIFF
--- a/lib/ourJoi.js
+++ b/lib/ourJoi.js
@@ -29,7 +29,12 @@ Joi.many = function(resource) {
   };
   return obj;
 };
+Joi._validateForeignRelation = function(config) {
+  if (!config.as) throw new Error("Missing 'as' property when defining a foreign relation");
+  if (!config.resource) throw new Error("Missing 'resource' property when defining a foreign relation");
+};
 Joi.belongsToOne = function(config) {
+  Joi._validateForeignRelation(config);
   var obj = Joi.alternatives().try(
     Joi.any().valid(null), // null
     ourJoi._joiBase(config.resource)
@@ -41,6 +46,7 @@ Joi.belongsToOne = function(config) {
   return obj;
 };
 Joi.belongsToMany = function(config) {
+  Joi._validateForeignRelation(config);
   var obj = Joi.array().items(ourJoi._joiBase(config.resource));
   obj._settings = {
     __many: config.resource,


### PR DESCRIPTION
This PR ensures we error hard and fast when someone attempts to incorrectly define a foreign relation.

For example, this:
```javascript
    articles: jsonApi.Joi.belongsToMany({
      resource: "articles",
      // as: "author"
    }),
```

Will now result in:
```
/repos/jsonapi-server/lib/ourJoi.js:33
  if (!config.as) throw new Error("Missing 'as' property when defining a foreign relation");
                  ^

Error: Missing 'as' property when defining a foreign relation
    at Joi._validateForeignRelation (/repos/jsonapi-server/lib/ourJoi.js:33:25)
    at Joi.belongsToMany (/repos/jsonapi-server/lib/ourJoi.js:49:7)
    at Object.<anonymous> (/repos/jsonapi-server/example/resources/people.js:19:27)
```