### PR TITLE
Respond with 204 OK + CORS to OPTIONS requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,3 +75,5 @@
 2015-01-11 - Updating dependencies
 2015-01-11 - Error hard and fast when incorrectly defining foreign relations
 2015-01-11 - v1.1.0
+2015-01-21 - Set better default CORS headers
+2015-01-21 - v1.2.0

--- a/lib/router.js
+++ b/lib/router.js
@@ -50,8 +50,8 @@ app.use(function(req, res, next) {
   res.set({
     "Content-Type": "application/vnd.api+json",
     "Access-Control-Allow-Origin": "*",
-    "Access-Control-Allow-Methods": "*",
-    "Access-Control-Allow-Headers": "*"
+    "Access-Control-Allow-Methods": "GET, POST, PATCH, DELETE, OPTIONS",
+    "Access-Control-Allow-Headers": req.headers["access-control-request-headers"] || ""
   });
 
   if (req.method === "OPTIONS") {

--- a/lib/router.js
+++ b/lib/router.js
@@ -46,6 +46,20 @@ app.use(function(req, res, next) {
   return next();
 });
 
+app.use(function(req, res, next) {
+  res.set({
+    "Content-Type": "application/vnd.api+json",
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "*"
+  });
+
+  if (req.method === "OPTIONS") {
+    return res.status(204).end();
+  }
+
+  return next();
+});
+
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(cookieParser());
@@ -74,7 +88,6 @@ router.bindRoute = function(config, callback) {
   app[config.verb](jsonApi._apiConfig.base + config.path, function(req, res) {
     var request = router._getParams(req);
     var resourceConfig = jsonApi._resources[request.params.type];
-    router._setResponseHeaders(request, res);
     request.resourceConfig = resourceConfig;
     router.authenticate(request, res, function() {
       return callback(request, resourceConfig, res);
@@ -99,7 +112,6 @@ router.authenticateWith = function(authFunction) {
 router.bind404 = function(callback) {
   app.use(function(req, res) {
     var request = router._getParams(req);
-    router._setResponseHeaders(request, res);
     return callback(request, res);
   });
 };
@@ -107,7 +119,6 @@ router.bind404 = function(callback) {
 router.bindErrorHandler = function(callback) {
   app.use(function(error, req, res, next) {
     var request = router._getParams(req);
-    router._setResponseHeaders(request, res);
     return callback(request, res, error, next);
   });
 };
@@ -139,15 +150,6 @@ router._getParams = function(req) {
       }) + req.url
     }
   };
-};
-
-router._setResponseHeaders = function(request, res) {
-  res.set({
-    "Content-Type": "application/vnd.api+json",
-    "Location": request.route.combined,
-    "Access-Control-Allow-Origin": "*",
-    "Access-Control-Allow-Methods": "*"
-  });
 };
 
 router.sendResponse = function(res, payload, httpCode) {

--- a/lib/router.js
+++ b/lib/router.js
@@ -50,7 +50,8 @@ app.use(function(req, res, next) {
   res.set({
     "Content-Type": "application/vnd.api+json",
     "Access-Control-Allow-Origin": "*",
-    "Access-Control-Allow-Methods": "*"
+    "Access-Control-Allow-Methods": "*",
+    "Access-Control-Allow-Headers": "*"
   });
 
   if (req.method === "OPTIONS") {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-server",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A config driven NodeJS framework implementing json:api",
   "keywords": [
     "jsonapi",

--- a/test/options.js
+++ b/test/options.js
@@ -1,0 +1,33 @@
+"use strict";
+var assert = require("assert");
+var request = require("request");
+var jsonApiTestServer = require("../example/server");
+
+
+describe("Testing jsonapi-server", function() {
+
+  describe("OPTIONS request", function() {
+
+    it("returns 204", function(done) {
+      var url = "http://localhost:16006/rest/";
+      request({
+        method: "OPTIONS",
+        url: url
+      }, function(err, res) {
+        assert(!err);
+        assert.strictEqual(res.statusCode, 204, "Expecting 200 OK");
+        assert.equal(res.headers["content-type"], "application/vnd.api+json", "should have a content-type");
+        assert.equal(res.headers["access-control-allow-origin"], "*", "should have CORS headers");
+        assert.equal(res.headers["access-control-allow-methods"], "*", "should have CORS headers");
+        done();
+      });
+    });
+  });
+
+  before(function() {
+    jsonApiTestServer.start();
+  });
+  after(function() {
+    jsonApiTestServer.close();
+  });
+});

--- a/test/options.js
+++ b/test/options.js
@@ -19,6 +19,7 @@ describe("Testing jsonapi-server", function() {
         assert.equal(res.headers["content-type"], "application/vnd.api+json", "should have a content-type");
         assert.equal(res.headers["access-control-allow-origin"], "*", "should have CORS headers");
         assert.equal(res.headers["access-control-allow-methods"], "*", "should have CORS headers");
+        assert.equal(res.headers["access-control-allow-headers"], "*", "should have CORS headers");
         done();
       });
     });

--- a/test/options.js
+++ b/test/options.js
@@ -18,8 +18,8 @@ describe("Testing jsonapi-server", function() {
         assert.strictEqual(res.statusCode, 204, "Expecting 200 OK");
         assert.equal(res.headers["content-type"], "application/vnd.api+json", "should have a content-type");
         assert.equal(res.headers["access-control-allow-origin"], "*", "should have CORS headers");
-        assert.equal(res.headers["access-control-allow-methods"], "*", "should have CORS headers");
-        assert.equal(res.headers["access-control-allow-headers"], "*", "should have CORS headers");
+        assert.equal(res.headers["access-control-allow-methods"], "GET, POST, PATCH, DELETE, OPTIONS", "should have CORS headers");
+        assert.equal(res.headers["access-control-allow-headers"], "", "should have CORS headers");
         done();
       });
     });


### PR DESCRIPTION
I've refactored response headers a little to make it more consistent, and we're now responding with HTTP 204 instead of 404 for OPTIONS request. There's a new test to prevent any regressions.