### PR TITLE
Aggressive cache-expiry headers by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,3 +77,5 @@
 2015-01-11 - v1.1.0
 2015-01-21 - Set better default CORS headers
 2015-01-21 - v1.2.0
+2015-01-25 - Aggressive cache-expiry headers by default
+2015-01-25 - v1.3.0

--- a/lib/router.js
+++ b/lib/router.js
@@ -51,7 +51,9 @@ app.use(function(req, res, next) {
     "Content-Type": "application/vnd.api+json",
     "Access-Control-Allow-Origin": "*",
     "Access-Control-Allow-Methods": "GET, POST, PATCH, DELETE, OPTIONS",
-    "Access-Control-Allow-Headers": req.headers["access-control-request-headers"] || ""
+    "Access-Control-Allow-Headers": req.headers["access-control-request-headers"] || "",
+    "Cache-Control": "private, must-revalidate, max-age=0",
+    "Expires": "Thu, 01 Jan 1970 00:00:00"
   });
 
   if (req.method === "OPTIONS") {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-server",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A config driven NodeJS framework implementing json:api",
   "keywords": [
     "jsonapi",

--- a/test/options.js
+++ b/test/options.js
@@ -20,6 +20,8 @@ describe("Testing jsonapi-server", function() {
         assert.equal(res.headers["access-control-allow-origin"], "*", "should have CORS headers");
         assert.equal(res.headers["access-control-allow-methods"], "GET, POST, PATCH, DELETE, OPTIONS", "should have CORS headers");
         assert.equal(res.headers["access-control-allow-headers"], "", "should have CORS headers");
+        assert.equal(res.headers["cache-control"], "private, must-revalidate, max-age=0", "should have non-caching headers");
+        assert.equal(res.headers.expires, "Thu, 01 Jan 1970 00:00:00", "should have non-caching headers");
         done();
       });
     });


### PR DESCRIPTION
I've seen some browsers (IE9 + IE11) aggressively cache API responses, so much so that this chain of requests won't behave as expected:
 1. Find resource 1234
 2. Delete resource 1234
 3. Find resource 1234 <--- still works, returns { }

This PR adds some headers so the default behaviour says "please don't ever cache this".