### PR TITLE
Handle missing to-one related resource.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,81 +1,81 @@
-2015-06-29 - Initial release
-2015-07-03 - Refactoring handlers to improve readability
-2915-07-03 - Separating out route handlers into separate files
-2015-07-05 - Allow user to implement their own error logging
-2015-07-06 - Handle 404s and allow logging for uncaught exceptions
-2015-07-08 - Added additional info to relation metadata
-2015-07-11 - Code Complexity tool via npm-run-complexity
-2015-07-12 - v0.7.0
-2015-07-12 - Split postProcessing into smaller modules
-2015-07-12 - Split out Joi modifications into separate file
-2015-07-13 - Split out documentation into more manageable chunks
-2015-07-13 - Updating dependencies to latest stable releases
-2015-07-13 - v0.8.0
-2015-09-25 - Enabling meta blocks on Resources and Relations
-2015-09-25 - Adding cookies to Request objects
-2015-09-25 - Updating dependencies
-2015-09-25 - Enable basic authentication
-2015-09-25 - Validate attribute names
-2015-09-25 - Stricter handling of HTTP Accept headers
-2015-09-25 - Stricter handling of HTTP Content-Type headers
-2015-09-27 - Improve validation when updating a relationship
-2015-09-27 - v0.9.0
-2015-09-27 - Always respond with absolute URLs
-2015-11-05 - v0.10.0
-2015-11-06 - Improve resource-update validation
-2015-11-06 - v0.11.0
-2015-11-09 - Ignore non-js routes within the example app
-2015-11-09 - Pass around headers on inclusion requests
-2015-11-09 - Creating resources gives a 201 CREATED
-2015-11-10 - Additional error handling for foreign relation lookup
-2015-11-10 - Additional error detail on 403 and 404
-2015-11-10 - v0.12.0
-2015-11-11 - Correctly build related URLs when using HTTPS
-2015-11-11 - v0.12.1
-2015-11-11 - Blacklist some HTTP headers we dont want to pass onwards
-2015-11-11 - v0.12.2
-2015-11-12 - Handlers readiness check
-2015-11-12 - v0.13.0
-2015-11-17 - Additional error handling for foreign relation lookup
-2015-11-17 - v0.13.1
-2015-11-17 - Handlers are now objects instead of modules
-2015-11-17 - v0.14.0
-2015-11-18 - Rename MockHandler to MemoryHandler
-2015-11-18 - v0.15.0
-2015-11-18 - Updated documentation
-2015-11-18 - v0.15.1
-2015-11-19 - Validate filter params before handing over to resourceHandler.search
-2015-11-19 - v0.15.2
-2015-11-25 - Automatic Swagger Generation
-2015-11-25 - Debugging functionality
-2015-11-25 - Validation around handlers behaviour
-2015-11-25 - v0.16.0
-2015-12-03 - Top level jsonapi blocks
-2015-12-05 - Tooling improvements
-2015-12-07 - Efficient inclusions
-2015-12-08 - Pagination support
-2015-12-10 - CPU profiling
-2015-12-10 - Move to lodash
-2015-12-10 - Use filter[] instead of relationships[]
-2015-12-10 - Inclusion bug fixes
-2015-12-10 - v1.0.0
-2015-12-10 - Correcting v8-profiler dependency
-2015-12-10 - v1.0.1
-2015-12-11 - Test harness improvements
-2015-12-11 - v1.0.2
-2015-12-17 - Don't pass on content-length HTTP headers on inclusion requests
-2015-12-17 - Filter won't match undefined properties anymore
-2015-12-17 - v1.0.3
-2015-12-30 - Enable path-less API
-2015-12-30 - v1.0.4
-2015-12-31 - Set Location header correctly when creating resources
-2015-12-31 - v1.0.5
-2015-01-11 - Big documentation improvements
-2015-01-11 - Sanitise input + output with Joi
-2015-01-11 - Updating dependencies
-2015-01-11 - Error hard and fast when incorrectly defining foreign relations
-2015-01-11 - v1.1.0
-2015-01-21 - Set better default CORS headers
-2015-01-21 - v1.2.0
-2015-01-25 - Aggressive cache-expiry headers by default
-2015-01-25 - v1.3.0
+- 2016-01-25 - v1.3.0
+- 2016-01-25 - Aggressive cache-expiry headers by default
+- 2016-01-21 - v1.2.0
+- 2016-01-21 - Set better default CORS headers
+- 2016-01-11 - v1.1.0
+- 2016-01-11 - Error hard and fast when incorrectly defining foreign relations
+- 2016-01-11 - Updating dependencies
+- 2016-01-11 - Sanitise input + output with Joi
+- 2016-01-11 - Big documentation improvements
+- 2015-12-31 - v1.0.5
+- 2015-12-31 - Set Location header correctly when creating resources
+- 2015-12-30 - v1.0.4
+- 2015-12-30 - Enable path-less API
+- 2015-12-17 - v1.0.3
+- 2015-12-17 - Filter won't match undefined properties anymore
+- 2015-12-17 - Don't pass on content-length HTTP headers on inclusion requests
+- 2015-12-11 - v1.0.2
+- 2015-12-11 - Test harness improvements
+- 2015-12-10 - v1.0.1
+- 2015-12-10 - Correcting v8-profiler dependency
+- 2015-12-10 - v1.0.0
+- 2015-12-10 - Inclusion bug fixes
+- 2015-12-10 - Use filter[] instead of relationships[]
+- 2015-12-10 - Move to lodash
+- 2015-12-10 - CPU profiling
+- 2015-12-08 - Pagination support
+- 2015-12-07 - Efficient inclusions
+- 2015-12-05 - Tooling improvements
+- 2015-12-03 - Top level jsonapi blocks
+- 2015-11-25 - v0.16.0
+- 2015-11-25 - Validation around handlers behaviour
+- 2015-11-25 - Debugging functionality
+- 2015-11-25 - Automatic Swagger Generation
+- 2015-11-19 - v0.15.2
+- 2015-11-19 - Validate filter params before handing over to resourceHandler.search
+- 2015-11-18 - v0.15.1
+- 2015-11-18 - Updated documentation
+- 2015-11-18 - v0.15.0
+- 2015-11-18 - Rename MockHandler to MemoryHandler
+- 2015-11-17 - v0.14.0
+- 2015-11-17 - Handlers are now objects instead of modules
+- 2015-11-17 - v0.13.1
+- 2015-11-17 - Additional error handling for foreign relation lookup
+- 2015-11-12 - v0.13.0
+- 2015-11-12 - Handlers readiness check
+- 2015-11-11 - v0.12.2
+- 2015-11-11 - Blacklist some HTTP headers we dont want to pass onwards
+- 2015-11-11 - v0.12.1
+- 2015-11-11 - Correctly build related URLs when using HTTPS
+- 2015-11-10 - v0.12.0
+- 2015-11-10 - Additional error detail on 403 and 404
+- 2015-11-10 - Additional error handling for foreign relation lookup
+- 2015-11-09 - Creating resources gives a 201 CREATED
+- 2015-11-09 - Pass around headers on inclusion requests
+- 2015-11-09 - Ignore non-js routes within the example app
+- 2015-11-06 - v0.11.0
+- 2015-11-06 - Improve resource-update validation
+- 2015-11-05 - v0.10.0
+- 2015-09-27 - Always respond with absolute URLs
+- 2015-09-27 - v0.9.0
+- 2015-09-27 - Improve validation when updating a relationship
+- 2015-09-25 - Stricter handling of HTTP Content-Type headers
+- 2015-09-25 - Stricter handling of HTTP Accept headers
+- 2015-09-25 - Validate attribute names
+- 2015-09-25 - Enable basic authentication
+- 2015-09-25 - Updating dependencies
+- 2015-09-25 - Adding cookies to Request objects
+- 2015-09-25 - Enabling meta blocks on Resources and Relations
+- 2015-07-13 - v0.8.0
+- 2015-07-13 - Updating dependencies to latest stable releases
+- 2015-07-13 - Split out documentation into more manageable chunks
+- 2015-07-12 - Split out Joi modifications into separate file
+- 2015-07-12 - Split postProcessing into smaller modules
+- 2015-07-12 - v0.7.0
+- 2015-07-11 - Code Complexity tool via npm-run-complexity
+- 2015-07-08 - Added additional info to relation metadata
+- 2015-07-06 - Handle 404s and allow logging for uncaught exceptions
+- 2015-07-05 - Allow user to implement their own error logging
+- 2015-07-03 - Separating out route handlers into separate files
+- 2015-07-03 - Refactoring handlers to improve readability
+- 2015-06-29 - Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- 2016-02-10 - v1.3.1
+- 2016-02-10 - Correctly handle missing to-one related resources
 - 2016-01-25 - v1.3.0
 - 2016-01-25 - Aggressive cache-expiry headers by default
 - 2016-01-21 - v1.2.0

--- a/example/resources/comments.js
+++ b/example/resources/comments.js
@@ -35,6 +35,13 @@ jsonApi.define({
       body: "I like XML better",
       timestamp: "2017-06-20",
       author: { type: "people", id: "32fb0105-acaa-4adb-9ec4-8b49633695e1", meta: { created: "2010-01-01" } }
+    },
+    {
+      id: "2f716574-cef6-4238-8285-520911af86c1",
+      type: "comments",
+      body: "Wibble wibble.",
+      timestamp: "2017-12-31",
+      author: null
     }
   ]
 });

--- a/lib/postProcess.js
+++ b/lib/postProcess.js
@@ -35,6 +35,9 @@ postProcess._fetchRelatedResources = function(request, mainResource, callback) {
 
   // Fetch the other objects
   var dataItems = mainResource[request.params.relation];
+
+  if (!dataItems) return callback(null, [ null ]);
+
   if (!(dataItems instanceof Array)) dataItems = [ dataItems ];
 
   var resourcesToFetch = dataItems.reduce(function(map, dataItem) {

--- a/lib/routes/related.js
+++ b/lib/routes/related.js
@@ -57,7 +57,9 @@ relatedRoute.register = function() {
         }
         request.resourceConfig = jsonApi._resources[relation._settings.__one || relation._settings.__many];
         response = responseHelper._generateResponse(request, resourceConfig, relatedResources);
-        response.included = [ ];
+        if (relatedResources !== null) {
+          response.included = [ ];
+        }
         postProcess.handle(request, response, callback);
       }
     ], function(err) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-server",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A config driven NodeJS framework implementing json:api",
   "keywords": [
     "jsonapi",

--- a/test/_preResourceValidationCheck.js
+++ b/test/_preResourceValidationCheck.js
@@ -7,7 +7,7 @@ var jsonApiTestServer = require("../example/server.js");
 describe("Testing jsonapi-server", function() {
 
   [ { name: "articles", count: 4 },
-    { name: "comments", count: 2 },
+    { name: "comments", count: 3 },
     { name: "people", count: 4 },
     { name: "photos", count: 3 },
     { name: "tags", count: 5 }

--- a/test/get-resource-id-related.js
+++ b/test/get-resource-id-related.js
@@ -66,6 +66,23 @@ describe("Testing jsonapi-server", function() {
       });
     });
 
+    it("with null data", function(done) {
+      var url = "http://localhost:16006/rest/comments/2f716574-cef6-4238-8285-520911af86c1/author";
+      helpers.request({
+        method: "GET",
+        url: url
+      }, function(err, res, json) {
+        assert.equal(err, null);
+        json = helpers.validateJson(json);
+        assert.equal(res.statusCode, "200", "Expecting 200 OK");
+        assert.strictEqual(json.data, null);
+        assert(!("included" in json), "Null resource not NOT have `includes` attribute");
+
+        done();
+
+      });
+    });
+
     it("with fields", function(done) {
       var url = "http://localhost:16006/rest/articles/de305d54-75b4-431b-adb2-eb6b9e546014/author?fields[people]=email";
       helpers.request({

--- a/test/zzPostResourceValidationCheck.js
+++ b/test/zzPostResourceValidationCheck.js
@@ -7,7 +7,7 @@ var jsonApiTestServer = require("../example/server.js");
 describe("Testing jsonapi-server", function() {
 
   [ { name: "articles", count: 4 },
-    { name: "comments", count: 1 },
+    { name: "comments", count: 2 },
     { name: "people", count: 4 },
     { name: "photos", count: 4 },
     { name: "tags", count: 5 }


### PR DESCRIPTION
Correctly handle missing to-one related resource by returning a `null` resource that following the specification (see http://jsonapi.org/format/#fetching-relationships). Fixes #97.

* [x] :ok: 
* [x] :ok_hand: 