### PR TITLE
Filter by non-string attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- 2016-02-16 - v1.3.2
+- 2016-02-16 - Correctly filter by non-string attributes
 - 2016-02-10 - v1.3.1
 - 2016-02-10 - Correctly handle missing to-one related resources
 - 2016-01-25 - v1.3.0

--- a/example/resources/articles.js
+++ b/example/resources/articles.js
@@ -39,6 +39,7 @@ jsonApi.define({
       type: "articles",
       title: "NodeJS Best Practices",
       content: "na",
+      created: "2016-01-05",
       author: {
         type: "people",
         id: "cc5cca2e-0dd8-4b95-8cfc-a11230e73116",
@@ -60,6 +61,7 @@ jsonApi.define({
       type: "articles",
       title: "Linux Rocks",
       content: "na",
+      created: "2015-11-11",
       author: { type: "people", id: "d850ea75-4427-4f81-8595-039990aeede5" },
       tags: [
         { type: "tags", id: "2a3bdea4-a889-480d-b886-104498c86f69" }
@@ -75,6 +77,7 @@ jsonApi.define({
       type: "articles",
       title: "How to AWS",
       content: "na",
+      created: "2016-02-08",
       author: { type: "people", id: "32fb0105-acaa-4adb-9ec4-8b49633695e1" },
       tags: [
         { type: "tags", id: "8d196606-134c-4504-a93a-0d372f78d6c5" }
@@ -89,6 +92,7 @@ jsonApi.define({
       type: "articles",
       title: "Tea for Beginners",
       content: "na",
+      created: "2015-06-23",
       author: { type: "people", id: "ad3aa89e-9c5b-4ac9-a652-6670f9f27587" },
       tags: [
         { type: "tags", id: "6ec62f6d-9f82-40c5-b4f4-279ed1765492" },

--- a/example/resources/articles.js
+++ b/example/resources/articles.js
@@ -18,12 +18,14 @@ jsonApi.define({
     content: jsonApi.Joi.string().required()
       .description("The main body of the article, provided as HTML")
       .example("<p>Paragraph 1. Lovely.</p><hr /><p>The End.</p>"),
-    created: jsonApi.Joi.date().format("YYYY-MM-DD")
+    created: jsonApi.Joi.string().regex(/^[12]\d\d\d-[01]\d-[0123]\d$/)
       .description("The date on which the article was created, YYYY-MM-DD")
       .example("2017-05-01"),
     status: jsonApi.Joi.string().default("published")
       .description("The status of the article - draft, ready, published")
       .example("published"),
+    views: jsonApi.Joi.number().default(0)
+      .description("Number of views for this article"),
     author: jsonApi.Joi.one("people")
       .description("The person who wrote the article"),
     tags: jsonApi.Joi.many("tags")
@@ -40,6 +42,7 @@ jsonApi.define({
       title: "NodeJS Best Practices",
       content: "na",
       created: "2016-01-05",
+      views: 10,
       author: {
         type: "people",
         id: "cc5cca2e-0dd8-4b95-8cfc-a11230e73116",
@@ -62,6 +65,7 @@ jsonApi.define({
       title: "Linux Rocks",
       content: "na",
       created: "2015-11-11",
+      views: 20,
       author: { type: "people", id: "d850ea75-4427-4f81-8595-039990aeede5" },
       tags: [
         { type: "tags", id: "2a3bdea4-a889-480d-b886-104498c86f69" }
@@ -78,6 +82,7 @@ jsonApi.define({
       title: "How to AWS",
       content: "na",
       created: "2016-02-08",
+      views: 30,
       author: { type: "people", id: "32fb0105-acaa-4adb-9ec4-8b49633695e1" },
       tags: [
         { type: "tags", id: "8d196606-134c-4504-a93a-0d372f78d6c5" }
@@ -93,6 +98,7 @@ jsonApi.define({
       title: "Tea for Beginners",
       content: "na",
       created: "2015-06-23",
+      views: 40,
       author: { type: "people", id: "ad3aa89e-9c5b-4ac9-a652-6670f9f27587" },
       tags: [
         { type: "tags", id: "6ec62f6d-9f82-40c5-b4f4-279ed1765492" },

--- a/lib/postProcessing/filter.js
+++ b/lib/postProcessing/filter.js
@@ -2,7 +2,8 @@
 var filter = module.exports = { };
 
 var _ = {
-  assign: require("lodash.assign")
+  assign: require("lodash.assign"),
+  isEqual: require("lodash.isequal")
 };
 var debug = require("../debugging.js");
 
@@ -64,7 +65,7 @@ filter._filterMatches = function(filterElementStr, attributeValue, attributeConf
   }
   filterElement.value = validationResult.value;
   if (!filterElement.operator) {
-    return attributeValue === filterElement.value;
+    return _.isEqual(attributeValue, filterElement.value);
   }
   if (["~", ":"].indexOf(filterElement.operator) !== -1 && typeof filterElement.value !== "string") {
     return false;

--- a/lib/postProcessing/filter.js
+++ b/lib/postProcessing/filter.js
@@ -6,6 +6,8 @@ var _ = {
 };
 var debug = require("../debugging.js");
 
+var FILTER_OPERATORS = ["<", ">", "~", ":"];
+
 filter.action = function(request, response, callback) {
   var allFilters = _.assign({ }, request.params.filter);
   if (!allFilters) return callback();
@@ -30,14 +32,14 @@ filter.action = function(request, response, callback) {
 
   if (response.data instanceof Array) {
     for (var j = 0; j < response.data.length; j++) {
-      if (!filter._filterKeepObject(response.data[j], filters)) {
+      if (!filter._filterKeepObject(response.data[j], filters, request.resourceConfig.attributes)) {
         debug.filter("removed", filters, JSON.stringify(response.data[j].attributes));
         response.data.splice(j, 1);
         j--;
       }
     }
   } else if (response.data instanceof Object) {
-    if (!filter._filterKeepObject(response.data, filters)) {
+    if (!filter._filterKeepObject(response.data, filters, request.resourceConfig.attributes)) {
       debug.filter("removed", filters, JSON.stringify(response.data.attributes));
       response.data = null;
     }
@@ -46,30 +48,54 @@ filter.action = function(request, response, callback) {
   return callback();
 };
 
-filter._filterMatches = function(textToMatch, propertyText) {
-  if (textToMatch[0] === ">") {
-    textToMatch = textToMatch.substring(1);
-    if (typeof propertyText === "number") textToMatch = parseInt(textToMatch, 10);
-    if (textToMatch < propertyText) return true;
-  } else if (textToMatch[0] === "<") {
-    textToMatch = textToMatch.substring(1);
-    if (typeof propertyText === "number") textToMatch = parseInt(textToMatch, 10);
-    if (textToMatch > propertyText) return true;
-  } else if (textToMatch[0] === "~") {
-    if ((textToMatch.substring(1) + "").toLowerCase() === (propertyText + "").toLowerCase()) return true;
-  } else if (textToMatch[0] === ":") {
-    if ((propertyText + "").toLowerCase().indexOf((textToMatch.substring(1) + "").toLowerCase()) !== -1) return true;
-  } else if (textToMatch === propertyText) return true;
+filter._splitFilterElement = function(filterElementStr) {
+  if (FILTER_OPERATORS.indexOf(filterElementStr[0]) !== -1) {
+    return { operator: filterElementStr[0], value: filterElementStr.substring(1) };
+  }
+  return { operator: null, value: filterElementStr };
 };
 
-filter._filterKeepObject = function(someObject, filters) {
+filter._filterMatches = function(filterElementStr, attributeValue, attributeConfig) {
+  var filterElement = filter._splitFilterElement(filterElementStr);
+  var validationResult = attributeConfig.validate(filterElement.value);
+  if (validationResult.error) {
+    debug.filter("invalid filter condition value:", validationResult.error);
+    return false;
+  }
+  filterElement.value = validationResult.value;
+  if (!filterElement.operator) {
+    return attributeValue === filterElement.value;
+  }
+  if (["~", ":"].indexOf(filterElement.operator) !== -1 && typeof filterElement.value !== "string") {
+    return false;
+  }
+  var filterFunction = {
+    ">": function filterGreaterThan(attrValue, filterValue) {
+      return attrValue > filterValue;
+    },
+    "<": function filterLessThan(attrValue, filterValue) {
+      return attrValue < filterValue;
+    },
+    "~": function filterCaseInsensitiveEqual(attrValue, filterValue) {
+      return attrValue.toLowerCase() === filterValue.toLowerCase();
+    },
+    ":": function filterCaseInsensitiveContains(attrValue, filterValue) {
+      return attrValue.toLowerCase().indexOf(filterValue.toLowerCase()) !== -1;
+    }
+  }[filterElement.operator];
+  var result = filterFunction(attributeValue, filterElement.value);
+  return result;
+};
+
+filter._filterKeepObject = function(someObject, filters, attributesConfig) {
   for (var filterName in filters) {
     var whitelist = filters[filterName].split(",");
+    var attributeConfig = attributesConfig[filterName];
 
     if (someObject.attributes.hasOwnProperty(filterName) || (filterName === "id")) {
       var attributeValue = someObject.attributes[filterName] || "";
       if (filterName === "id") attributeValue = someObject.id;
-      var attributeMatches = filter._attributesMatchesOR(attributeValue, whitelist);
+      var attributeMatches = filter._attributesMatchesOR(attributeValue, attributeConfig, whitelist);
       if (!attributeMatches) return false;
     } else if (someObject.relationships.hasOwnProperty(filterName)) {
       var relationships = someObject.relationships[filterName] || "";
@@ -82,10 +108,10 @@ filter._filterKeepObject = function(someObject, filters) {
   return true;
 };
 
-filter._attributesMatchesOR = function(attributeValue, whitelist) {
+filter._attributesMatchesOR = function(attributeValue, attributeConfig, whitelist) {
   var matchOR = false;
-  whitelist.forEach(function(textToMatch) {
-    if (filter._filterMatches(textToMatch, attributeValue)) {
+  whitelist.forEach(function(filterElementStr) {
+    if (filter._filterMatches(filterElementStr, attributeValue, attributeConfig)) {
       matchOR = true;
     }
   });
@@ -103,8 +129,8 @@ filter._relationshipMatchesOR = function(relationships, whitelist) {
     return relation.id;
   });
 
-  whitelist.forEach(function(textToMatch) {
-    if (data.indexOf(textToMatch) !== -1) {
+  whitelist.forEach(function(filterElementStr) {
+    if (data.indexOf(filterElementStr) !== -1) {
       matchOR = true;
     }
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-server",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "A config driven NodeJS framework implementing json:api",
   "keywords": [
     "jsonapi",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "express": "4.13.3",
     "joi": "6.10.1",
     "lodash.assign": "3.2.0",
+    "lodash.isequal": "3.0.4",
     "lodash.omit": "3.1.0",
     "lodash.pick": "3.1.0",
     "lodash.uniq": "3.2.2",

--- a/test/get-resource.js
+++ b/test/get-resource.js
@@ -101,7 +101,7 @@ describe("Testing jsonapi-server", function() {
         });
       });
 
-      it("equality", function(done) {
+      it("equality for strings", function(done) {
         var url = "http://localhost:16006/rest/articles?filter[title]=How%20to%20AWS";
         helpers.request({
           method: "GET",
@@ -119,8 +119,8 @@ describe("Testing jsonapi-server", function() {
         });
       });
 
-      it("equality for non-string types", function(done) {
-        var url = "http://localhost:16006/rest/articles?filter[created]=2016-01-05";
+      it("equality for numbers", function(done) {
+        var url = "http://localhost:16006/rest/articles?filter[views]=10";
         helpers.request({
           method: "GET",
           url: url
@@ -137,7 +137,7 @@ describe("Testing jsonapi-server", function() {
         });
       });
 
-      it("less than", function(done) {
+      it("less than for strings", function(done) {
         var url = "http://localhost:16006/rest/articles?filter[title]=<M";
         helpers.request({
           method: "GET",
@@ -155,8 +155,8 @@ describe("Testing jsonapi-server", function() {
         });
       });
 
-      it("less than for non-string types", function(done) {
-        var url = "http://localhost:16006/rest/articles?filter[created]=<2016-01-01";
+      it("less than for numbers", function(done) {
+        var url = "http://localhost:16006/rest/articles?filter[views]=<23";
         helpers.request({
           method: "GET",
           url: url
@@ -167,13 +167,13 @@ describe("Testing jsonapi-server", function() {
           assert.equal(res.statusCode, "200", "Expecting 200 OK");
           var titles = json.data.map(function(i) { return i.attributes.title; });
           titles.sort();
-          assert.deepEqual(titles, [ "Linux Rocks", "Tea for Beginners" ], "expected matching resources");
+          assert.deepEqual(titles, [ "Linux Rocks", "NodeJS Best Practices" ], "expected matching resources");
 
           done();
         });
       });
 
-      it("greater than", function(done) {
+      it("greater than for strings", function(done) {
         var url = "http://localhost:16006/rest/articles?filter[title]=>M";
         helpers.request({
           method: "GET",
@@ -191,8 +191,8 @@ describe("Testing jsonapi-server", function() {
         });
       });
 
-      it("greater than for non-string types", function(done) {
-        var url = "http://localhost:16006/rest/articles?filter[created]=>2016-01-01";
+      it("greater than for numbers", function(done) {
+        var url = "http://localhost:16006/rest/articles?filter[views]=>27";
         helpers.request({
           method: "GET",
           url: url
@@ -203,7 +203,7 @@ describe("Testing jsonapi-server", function() {
           assert.equal(res.statusCode, "200", "Expecting 200 OK");
           var titles = json.data.map(function(i) { return i.attributes.title; });
           titles.sort();
-          assert.deepEqual(titles, [ "How to AWS", "NodeJS Best Practices" ], "expected matching resources");
+          assert.deepEqual(titles, [ "How to AWS", "Tea for Beginners" ], "expected matching resources");
 
           done();
         });

--- a/test/get-resource.js
+++ b/test/get-resource.js
@@ -101,6 +101,42 @@ describe("Testing jsonapi-server", function() {
         });
       });
 
+      it("equality", function(done) {
+        var url = "http://localhost:16006/rest/articles?filter[title]=How%20to%20AWS";
+        helpers.request({
+          method: "GET",
+          url: url
+        }, function(err, res, json) {
+          assert.equal(err, null);
+          json = helpers.validateJson(json);
+
+          assert.equal(res.statusCode, "200", "Expecting 200 OK");
+          var titles = json.data.map(function(i) { return i.attributes.title; });
+          titles.sort();
+          assert.deepEqual(titles, [ "How to AWS" ], "expected matching resources");
+
+          done();
+        });
+      });
+
+      it("equality for non-string types", function(done) {
+        var url = "http://localhost:16006/rest/articles?filter[created]=2016-01-05";
+        helpers.request({
+          method: "GET",
+          url: url
+        }, function(err, res, json) {
+          assert.equal(err, null);
+          json = helpers.validateJson(json);
+
+          assert.equal(res.statusCode, "200", "Expecting 200 OK");
+          var titles = json.data.map(function(i) { return i.attributes.title; });
+          titles.sort();
+          assert.deepEqual(titles, [ "NodeJS Best Practices" ], "expected matching resources");
+
+          done();
+        });
+      });
+
       it("less than", function(done) {
         var url = "http://localhost:16006/rest/articles?filter[title]=<M";
         helpers.request({

--- a/test/get-resource.js
+++ b/test/get-resource.js
@@ -119,6 +119,24 @@ describe("Testing jsonapi-server", function() {
         });
       });
 
+      it("less than for non-string types", function(done) {
+        var url = "http://localhost:16006/rest/articles?filter[created]=<2016-01-01";
+        helpers.request({
+          method: "GET",
+          url: url
+        }, function(err, res, json) {
+          assert.equal(err, null);
+          json = helpers.validateJson(json);
+
+          assert.equal(res.statusCode, "200", "Expecting 200 OK");
+          var titles = json.data.map(function(i) { return i.attributes.title; });
+          titles.sort();
+          assert.deepEqual(titles, [ "Linux Rocks", "Tea for Beginners" ], "expected matching resources");
+
+          done();
+        });
+      });
+
       it("greater than", function(done) {
         var url = "http://localhost:16006/rest/articles?filter[title]=>M";
         helpers.request({
@@ -132,6 +150,24 @@ describe("Testing jsonapi-server", function() {
           var titles = json.data.map(function(i) { return i.attributes.title; });
           titles.sort();
           assert.deepEqual(titles, [ "NodeJS Best Practices", "Tea for Beginners" ], "expected matching resources");
+
+          done();
+        });
+      });
+
+      it("greater than for non-string types", function(done) {
+        var url = "http://localhost:16006/rest/articles?filter[created]=>2016-01-01";
+        helpers.request({
+          method: "GET",
+          url: url
+        }, function(err, res, json) {
+          assert.equal(err, null);
+          json = helpers.validateJson(json);
+
+          assert.equal(res.statusCode, "200", "Expecting 200 OK");
+          var titles = json.data.map(function(i) { return i.attributes.title; });
+          titles.sort();
+          assert.deepEqual(titles, [ "How to AWS", "NodeJS Best Practices" ], "expected matching resources");
 
           done();
         });
@@ -154,6 +190,22 @@ describe("Testing jsonapi-server", function() {
         });
       });
 
+      it("case insensitive for non-string types", function(done) {
+        var url = "http://localhost:16006/rest/articles?filter[created]=~2016-01-01";
+        helpers.request({
+          method: "GET",
+          url: url
+        }, function(err, res, json) {
+          assert.equal(err, null);
+          json = helpers.validateJson(json);
+
+          assert.equal(res.statusCode, "200", "Expecting 200 OK");
+          assert.equal(json.data.length, 0, "didn't expect matching resources");
+
+          done();
+        });
+      });
+
       it("similar to", function(done) {
         var url = "http://localhost:16006/rest/articles?filter[title]=:for";
         helpers.request({
@@ -166,6 +218,22 @@ describe("Testing jsonapi-server", function() {
           assert.equal(res.statusCode, "200", "Expecting 200 OK");
           var titles = json.data.map(function(i) { return i.attributes.title; });
           assert.deepEqual(titles, [ "Tea for Beginners" ], "expected matching resources");
+
+          done();
+        });
+      });
+
+      it("similar to for non-string types", function(done) {
+        var url = "http://localhost:16006/rest/articles?filter[created]=:2016-01-01";
+        helpers.request({
+          method: "GET",
+          url: url
+        }, function(err, res, json) {
+          assert.equal(err, null);
+          json = helpers.validateJson(json);
+
+          assert.equal(res.statusCode, "200", "Expecting 200 OK");
+          assert.equal(json.data.length, 0, "didn't expect matching resources");
 
           done();
         });


### PR DESCRIPTION
Add support for correctly executing filtering operations when attributes that are not strings are involved. We now use Joi to validate the filter parameters and convert to the expected attribute type, which _should_ work for the supported Joi attribute types and make the comparisons work.

This fixes inequality filtering by attribute types such as integers and strings.

How can you test this? The new system tests cover inequality filtering by date attributes. Feel free to experiment with the sample resources definitions and test additional filtering cases.

* [x] :+1: 
* [x] :+1: :+1: 