### PR TITLE
Filtering falsy boolean values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- 2016-02-16 - v1.3.3
+- 2016-02-16 - Filtering falsy boolean values
 - 2016-02-16 - v1.3.2
 - 2016-02-16 - Correctly filter by non-string attributes
 - 2016-02-10 - v1.3.1

--- a/example/resources/photos.js
+++ b/example/resources/photos.js
@@ -20,6 +20,10 @@ jsonApi.define({
     width: jsonApi.Joi.number().min(1).max(10000).precision(0)
       .description("The photos width in pixels")
       .example(512),
+    raw: jsonApi.Joi.boolean()
+      .default(false)
+      .description("File in RAW format")
+      .example(false),
     photographer: jsonApi.Joi.one("people")
       .description("The person who took the photo"),
     articles: jsonApi.Joi.belongsToMany({
@@ -35,6 +39,7 @@ jsonApi.define({
       url: "http://www.example.com/foobar",
       height: 1080,
       width: 1920,
+      raw: true,
       photographer: { type: "people", id: "ad3aa89e-9c5b-4ac9-a652-6670f9f27587" }
     },
     {

--- a/lib/postProcessing/filter.js
+++ b/lib/postProcessing/filter.js
@@ -94,12 +94,12 @@ filter._filterKeepObject = function(someObject, filters, attributesConfig) {
     var attributeConfig = attributesConfig[filterName];
 
     if (someObject.attributes.hasOwnProperty(filterName) || (filterName === "id")) {
-      var attributeValue = someObject.attributes[filterName] || "";
+      var attributeValue = someObject.attributes[filterName];
       if (filterName === "id") attributeValue = someObject.id;
       var attributeMatches = filter._attributesMatchesOR(attributeValue, attributeConfig, whitelist);
       if (!attributeMatches) return false;
     } else if (someObject.relationships.hasOwnProperty(filterName)) {
-      var relationships = someObject.relationships[filterName] || "";
+      var relationships = someObject.relationships[filterName];
       var relationshipMatches = filter._relationshipMatchesOR(relationships, whitelist);
       if (!relationshipMatches) return false;
     } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-server",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "A config driven NodeJS framework implementing json:api",
   "keywords": [
     "jsonapi",

--- a/test/get-resource.js
+++ b/test/get-resource.js
@@ -137,6 +137,46 @@ describe("Testing jsonapi-server", function() {
         });
       });
 
+      describe("equality for booleans", function() {
+
+        it("matches false", function(done) {
+          var url = "http://localhost:16006/rest/photos?filter[raw]=false";
+          helpers.request({
+            method: "GET",
+            url: url
+          }, function(err, res, json) {
+            assert.equal(err, null);
+            json = helpers.validateJson(json);
+
+            assert.equal(res.statusCode, "200", "Expecting 200 OK");
+            var photoTypes = json.data.map(function(i) { return i.attributes.raw; });
+            assert.deepEqual(photoTypes, [ false, false ], "expected matching resources");
+
+            done();
+          });
+        });
+
+        it("matches true", function(done) {
+          var url = "http://localhost:16006/rest/photos?filter[raw]=true";
+          helpers.request({
+            method: "GET",
+            url: url
+          }, function(err, res, json) {
+            assert.equal(err, null);
+            json = helpers.validateJson(json);
+
+            assert.equal(res.statusCode, "200", "Expecting 200 OK");
+            var photoTypes = json.data.map(function(i) { return i.attributes.raw; });
+            assert.deepEqual(photoTypes, [ true ], "expected matching resources");
+
+            done();
+          });
+        });
+
+
+      });
+
+
       it("less than for strings", function(done) {
         var url = "http://localhost:16006/rest/articles?filter[title]=<M";
         helpers.request({

--- a/test/swaggerValidator.js
+++ b/test/swaggerValidator.js
@@ -119,6 +119,10 @@ swaggerValidator._validateOther = function(model, payload, urlPath, validationPa
     if (typeof payload !== "number") {
       throw new Error("Swagger Validation: " + urlPath + " Expected number at " + validationPath + ", got " + typeof payload);
     }
+  } else if (model.type === "boolean") {
+    if (typeof payload !== "boolean") {
+      throw new Error("Swagger Validation: " + urlPath + " Expected boolean at " + validationPath + ", got " + typeof payload);
+    }
   } else {
     throw new Error("Swagger Validation: " + urlPath + " Unknown type " + model.type + " at " + validationPath);
   }


### PR DESCRIPTION
After adding a use case for booleans, falsy boolean values couldn't be filtered against.

New use cases have been added along with relevant unit tests.

This now allows filtering such as - `http://localhost:16006/rest/photos?filter[raw]=true` and `http://localhost:16006/rest/photos?filter[raw]=false`

- [x] :shipit: 
- [x] :+1: 