### PR TITLE
Fixed missing commas in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ jsonApi.define({
   resource: "photos",
   handlers: new jsonApi.MemoryHandler(),
   attributes: {
-    title: jsonApi.Joi.string()
-    url: jsonApi.Joi.string().uri()
-    height: jsonApi.Joi.number().min(1).max(10000).precision(0)
+    title: jsonApi.Joi.string(),
+    url: jsonApi.Joi.string().uri(),
+    height: jsonApi.Joi.number().min(1).max(10000).precision(0),
     width: jsonApi.Joi.number().min(1).max(10000).precision(0)
   }
 });


### PR DESCRIPTION
The tl;dr example wasn't working because commas were missing.