### PR TITLE
Return all validation errors

### DIFF
--- a/lib/routes/helper.js
+++ b/lib/routes/helper.js
@@ -12,13 +12,13 @@ var _ = {
 
 helper.validate = function(someObject, someDefinition, callback) {
   debug.validationInput(JSON.stringify(someObject));
-  Joi.validate(someObject, someDefinition, function (err, sanitisedObject) {
+  Joi.validate(someObject, someDefinition, { abortEarly: false }, function (err, sanitisedObject) {
     if (err) {
       return callback({
         status: "403",
         code: "EFORBIDDEN",
         title: "Param validation failed",
-        detail: err
+        detail: err.details
       });
     }
     _.assign(someObject, sanitisedObject);

--- a/test/post-resource.js
+++ b/test/post-resource.js
@@ -24,29 +24,22 @@ describe("Testing jsonapi-server", function() {
     it("errors if resource doesnt validate", function(done) {
       var data = {
         method: "post",
-        url: "http://localhost:16006/rest/photos",
+        url: "http://localhost:16006/rest/articles",
         headers: {
           "Content-Type": "application/vnd.api+json"
         },
         body: JSON.stringify({
           "data": {
             "type": "photos",
-            "attributes": {
-              "title": "Ember Hamster",
-              "height": 512,
-              "width": 1024
-            },
-            "relationships": {
-              "photographer": {
-                "data": { "type": "people", "id": "cc5cca2e-0dd8-4b95-8cfc-a11230e73116" }
-              }
-            }
+            "attributes": { },
+            "relationships": { }
           }
         })
       };
       helpers.request(data, function(err, res, json) {
         assert.equal(err, null);
         json = helpers.validateError(json);
+        assert.equal(json.errors[0].detail.length, 2, "Expecting several validation errors");
         assert.equal(res.statusCode, "403", "Expecting 403");
 
         done();


### PR DESCRIPTION
In master if we attempt to perform an action that fails validation, we will only be told about the first validation error. This PR enables us to respond with all validation errors. Here's a sample response taken from the test suite:

```javascript
{
  "jsonapi": {
    "version": "1.0"
  },
  "meta": {
    "description": "This block shows up in the root node of every payload"
  },
  "links": {
    "self": "http://localhost:16006/rest/articles"
  },
  "errors": [
    {
      "status": "403",
      "code": "EFORBIDDEN",
      "title": "Param validation failed",
      "detail": [
        {
          "message": "\"title\" is required",
          "path": "title",
          "type": "any.required",
          "context": {
            "key": "title"
          }
        },
        {
          "message": "\"content\" is required",
          "path": "content",
          "type": "any.required",
          "context": {
            "key": "content"
          }
        }
      ]
    }
  ]
}
```