### PR TITLE
Use Flow for some Static Analysis

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,10 @@
+[include]
+./lib/
+
+[ignore]
+.*bad-locale\.json
+
+[options]
+module.ignore_non_literal_requires=true
+munge_underscores=true
+suppress_comment= \\(.\\|\n\\)*\\$FlowFixMe

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ script: "npm run $TEST_STEP"
 env:
   matrix:
     - TEST_STEP=lint
+    - TEST_STEP=flow
     - TEST_STEP=test
 notifications:
   email: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,11 @@ To verify all the code changes pass our style guidelines:
 npm run lint
 ```
 
+To run the static analysis tool (provided by Flow):
+```
+npm run flow
+```
+
 To verify everything still behaves as expected:
 ```
 npm test

--- a/lib/MemoryHandler.js
+++ b/lib/MemoryHandler.js
@@ -1,3 +1,4 @@
+/* @flow weak */
 "use strict";
 var _ = {
   assign: require("lodash.assign")

--- a/lib/debugging.js
+++ b/lib/debugging.js
@@ -1,3 +1,4 @@
+/* @flow weak */
 "use strict";
 module.exports = {
   handler: {

--- a/lib/handlerEnforcer.js
+++ b/lib/handlerEnforcer.js
@@ -1,3 +1,4 @@
+/* @flow weak */
 "use strict";
 var handlerEnforcer = module.exports = { };
 
@@ -12,6 +13,10 @@ handlerEnforcer.wrap = function(handlers) {
 };
 
 handlerEnforcer._wrapHandler = function(handlers, operation, outCount) {
+  if (typeof outCount !== "number") {
+    throw new Error("Invalid use of handlerEnforcer._wrapHandler!");
+  }
+
   var original = handlers[operation];
   return function() {
     var argsIn = Array.prototype.slice.call(arguments);
@@ -20,6 +25,7 @@ handlerEnforcer._wrapHandler = function(handlers, operation, outCount) {
     argsIn.push(function() {
       var argsOut = Array.prototype.slice.call(arguments);
       argsOut = argsOut.slice(0, outCount);
+      // $FlowFixMe: We've already ruled out any other possible types for outCount?
       while (argsOut.length < outCount) {
         argsOut.push(null);
       }

--- a/lib/jsonApi.js
+++ b/lib/jsonApi.js
@@ -1,3 +1,4 @@
+/* @flow weak */
 "use strict";
 var jsonApi = module.exports = { };
 jsonApi._resources = { };

--- a/lib/ourJoi.js
+++ b/lib/ourJoi.js
@@ -1,3 +1,4 @@
+/* @flow weak */
 "use strict";
 var ourJoi = module.exports = { };
 

--- a/lib/pagination.js
+++ b/lib/pagination.js
@@ -1,3 +1,4 @@
+/* @flow weak */
 "use strict";
 var pagination = module.exports = { };
 

--- a/lib/postProcess.js
+++ b/lib/postProcess.js
@@ -1,3 +1,4 @@
+/* @flow weak */
 "use strict";
 var postProcess = module.exports = { };
 
@@ -68,6 +69,8 @@ postProcess._fetchRelatedResources = function(request, mainResource, callback) {
       } catch(e) {
         json = null;
       }
+
+      if (!json) return done(null, [ ]);
 
       if (externalRes.statusCode >= 400) {
         return done(json.errors);

--- a/lib/postProcessing/fields.js
+++ b/lib/postProcessing/fields.js
@@ -1,3 +1,4 @@
+/* @flow weak */
 "use strict";
 var fields = module.exports = { };
 

--- a/lib/postProcessing/filter.js
+++ b/lib/postProcessing/filter.js
@@ -1,3 +1,4 @@
+/* @flow weak */
 "use strict";
 var filter = module.exports = { };
 

--- a/lib/postProcessing/include.js
+++ b/lib/postProcessing/include.js
@@ -1,3 +1,4 @@
+/* @flow weak */
 "use strict";
 var includePP = module.exports = { };
 
@@ -201,6 +202,8 @@ includePP._fillIncludeTree = function(includeTree, request, callback) {
         debug.include("!!", JSON.stringify(json));
         json = null;
       }
+
+      if (!json) return done(null, [ ]);
 
       if (res.statusCode >= 400) {
         debug.include("!!", JSON.stringify(json));

--- a/lib/postProcessing/sort.js
+++ b/lib/postProcessing/sort.js
@@ -1,3 +1,4 @@
+/* @flow weak */
 "use strict";
 var sort = module.exports = { };
 

--- a/lib/responseHelper.js
+++ b/lib/responseHelper.js
@@ -1,3 +1,4 @@
+/* @flow weak */
 "use strict";
 var responseHelper = module.exports = { };
 
@@ -109,6 +110,7 @@ responseHelper._generateLink = function(item, schemaProperty, linkProperty) {
   };
 
   if (schemaProperty._settings.__many) {
+    // $FlowFixMe: the data property can be either undefined (not present), null or [ ]
     link.data = [ ];
     var linkItems = item[linkProperty];
     if (linkItems) {
@@ -126,6 +128,7 @@ responseHelper._generateLink = function(item, schemaProperty, linkProperty) {
   if (schemaProperty._settings.__one) {
     var linkItem = item[linkProperty];
     if (linkItem) {
+      // $FlowFixMe: the data property can be either undefined (not present), null or [ ]
       link.data = {
         type: linkItem.type,
         id: linkItem.id,
@@ -143,6 +146,7 @@ responseHelper._generateLink = function(item, schemaProperty, linkProperty) {
     // /rest/bookings/?filter[customer]=26aa8a92-2845-4e40-999f-1fa006ec8c63
     link.links.related = responseHelper._baseUrl + relatedResource + "/?filter[" + schemaProperty._settings.__as + "]=" + item.id;
     if (!item[linkProperty]) {
+      // $FlowFixMe: the data property can be either undefined (not present), null or [ ]
       link.data = undefined;
     }
     link.meta = {

--- a/lib/router.js
+++ b/lib/router.js
@@ -1,3 +1,4 @@
+/* @flow weak */
 "use strict";
 var router = module.exports = { };
 

--- a/lib/routes/_foreignKeySearch.js
+++ b/lib/routes/_foreignKeySearch.js
@@ -1,3 +1,4 @@
+/* @flow weak */
 "use strict";
 var foreignKeySearchRoute = module.exports = { };
 

--- a/lib/routes/_swagger.js
+++ b/lib/routes/_swagger.js
@@ -1,3 +1,4 @@
+/* @flow weak */
 "use strict";
 var swagger = module.exports = { };
 

--- a/lib/routes/addRelation.js
+++ b/lib/routes/addRelation.js
@@ -1,3 +1,4 @@
+/* @flow weak */
 "use strict";
 var addRelationRoute = module.exports = { };
 

--- a/lib/routes/create.js
+++ b/lib/routes/create.js
@@ -1,3 +1,4 @@
+/* @flow weak */
 "use strict";
 var createRoute = module.exports = { };
 

--- a/lib/routes/delete.js
+++ b/lib/routes/delete.js
@@ -1,3 +1,4 @@
+/* @flow weak */
 "use strict";
 var deleteRoute = module.exports = { };
 

--- a/lib/routes/find.js
+++ b/lib/routes/find.js
@@ -1,3 +1,4 @@
+/* @flow weak */
 "use strict";
 var findRoute = module.exports = { };
 

--- a/lib/routes/helper.js
+++ b/lib/routes/helper.js
@@ -1,3 +1,4 @@
+/* @flow weak */
 "use strict";
 var helper = module.exports = { };
 

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -1,3 +1,4 @@
+/* @flow weak */
 "use strict";
 var routes = module.exports = { };
 

--- a/lib/routes/related.js
+++ b/lib/routes/related.js
@@ -1,3 +1,4 @@
+/* @flow weak */
 "use strict";
 var relatedRoute = module.exports = { };
 

--- a/lib/routes/relationships.js
+++ b/lib/routes/relationships.js
@@ -1,3 +1,4 @@
+/* @flow weak */
 "use strict";
 var relationshipsRoute = module.exports = { };
 

--- a/lib/routes/removeRelation.js
+++ b/lib/routes/removeRelation.js
@@ -1,3 +1,4 @@
+/* @flow weak */
 "use strict";
 var removeRelationRoute = module.exports = { };
 

--- a/lib/routes/search.js
+++ b/lib/routes/search.js
@@ -1,3 +1,4 @@
+/* @flow weak */
 "use strict";
 var searchRoute = module.exports = { };
 

--- a/lib/routes/update.js
+++ b/lib/routes/update.js
@@ -1,3 +1,4 @@
+/* @flow weak */
 "use strict";
 var updateRoute = module.exports = { };
 

--- a/lib/routes/updateRelation.js
+++ b/lib/routes/updateRelation.js
@@ -1,3 +1,4 @@
+/* @flow weak */
 "use strict";
 var updateRelationRoute = module.exports = { };
 

--- a/lib/routes/z404.js
+++ b/lib/routes/z404.js
@@ -1,3 +1,4 @@
+/* @flow weak */
 "use strict";
 var fourOhFour = module.exports = { };
 

--- a/lib/routes/zerrorHandler.js
+++ b/lib/routes/zerrorHandler.js
@@ -1,3 +1,4 @@
+/* @flow weak */
 "use strict";
 var errorHandler = module.exports = { };
 

--- a/lib/swagger/index.js
+++ b/lib/swagger/index.js
@@ -1,3 +1,4 @@
+/* @flow weak */
 "use strict";
 var swagger = module.exports = { };
 var jsonApi = require("../../");

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "cookie-parser": "1.4.0",
     "debug": "2.2.0",
     "express": "4.13.3",
+    "flow-bin": "^0.23.1",
     "joi": "6.10.1",
     "lodash.assign": "3.2.0",
     "lodash.isequal": "3.0.4",
@@ -51,7 +52,8 @@
     "coverage": "node ./node_modules/mocha/bin/mocha -S --require blanket --reporter html-cov ./test/*.js > coverage.html",
     "complexity": "node ./node_modules/plato/bin/plato -r -d complexity lib",
     "performance": "node --allow-natives-syntax --harmony ./node_modules/mocha/bin/_mocha -S --reporter mocha-performance ./test/*.js",
-    "lint": "node ./node_modules/eslint/bin/eslint ./example ./lib ./test --quiet && echo '✔ All good!'"
+    "lint": "node ./node_modules/eslint/bin/eslint ./example ./lib ./test --quiet && echo '✔ All good!'",
+    "flow": "node ./node_modules/flow-bin/cli.js && echo '✔ All good!'"
   },
   "config": {
     "blanket": {


### PR DESCRIPTION
This PR enables the user of the Flow project (http://flowtype.org/) in `weak` mode to detect various coding mistakes.

There are a few places notably the Swagger generator (/lib/swagger/*) where we generate JSON models based on configuration, which causes Flow to get a bit confused and complain that the generated JSON can differ. Those files don't opt in to the static analysis.

There were 4x examples of behaviour in the rest of the codebase that Flow isn't happy about but aren't issues. Those examples can be identified by the `// $FlowFixMe: ` comments inserted on the previous line to the non-issue.