### PR TITLE
Allow overriding debug function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- 2016-05-05 - v1.5.0
+- 2016-05-05 - Allow overriding debug output functions
+- 2016-04-27 - Static code analysis with Flow and JSCPD
 - 2016-04-22 - v1.4.0
 - 2016-04-22 - Return all validation errors
 - 2016-02-16 - v1.3.3

--- a/documentation/debugging.md
+++ b/documentation/debugging.md
@@ -25,3 +25,21 @@ $ DEBUG=jsonApi:handler:find npm test
 ```
 $ DEBUG=jsonApi:handler:* npm test
 ```
+
+### Integration with application logging
+
+If you wish to integrate `jsonapi-server` debug output with your application's logging solution, you can override the functions that are invoked for outputting the messages for the supported namespaces by invoking the package's `debugging.__overrideDebugOutput(outputFnFactory)` function where the `outputFnFactory` parameter is a function that expects a namespace string parameter and returns an output function for the namespace.
+
+A simple example of this functionality in action would be:
+
+```javascript
+var debugging = require("jsonapi-server/lib/debugging");
+
+var outputFnfactory = function(namespace) {
+  return function(message) {
+    console.log(namespace + ">>>", message);
+  }
+}
+
+debugging.__overrideDebugOutput(outputFnfactory);
+```

--- a/lib/debugging.js
+++ b/lib/debugging.js
@@ -1,18 +1,37 @@
 /* @flow weak */
 "use strict";
-module.exports = {
+
+var debug = require("debug");
+
+function overrideDebugOutputHelper(debugFns, outputFnFactory) {
+  Object.keys(debugFns).filter(function(key) {
+    return (key.substr(0, 2) !== "__");
+  }).forEach(function(key) {
+    if (debugFns[key] instanceof Function) {
+      debugFns[key] = outputFnFactory(debugFns[key].namespace);
+      return null;
+    }
+    return overrideDebugOutputHelper(debugFns[key], outputFnFactory);
+  });
+}
+
+var debugging = module.exports = {
   handler: {
-    search: require("debug")("jsonApi:handler:search"),
-    find: require("debug")("jsonApi:handler:find"),
-    create: require("debug")("jsonApi:handler:create"),
-    update: require("debug")("jsonApi:handler:update"),
-    delete: require("debug")("jsonApi:handler:delete")
+    search: debug("jsonApi:handler:search"),
+    find: debug("jsonApi:handler:find"),
+    create: debug("jsonApi:handler:create"),
+    update: debug("jsonApi:handler:update"),
+    delete: debug("jsonApi:handler:delete")
   },
-  include: require("debug")("jsonApi:include"),
-  filter: require("debug")("jsonApi:filter"),
-  validationInput: require("debug")("jsonApi:validation:input"),
-  validationOutput: require("debug")("jsonApi:validation:output"),
-  validationError: require("debug")("jsonApi:validation:error"),
-  errors: require("debug")("jsonApi:errors"),
-  requestCounter: require("debug")("jsonApi:requestCounter")
+  include: debug("jsonApi:include"),
+  filter: debug("jsonApi:filter"),
+  validationInput: debug("jsonApi:validation:input"),
+  validationOutput: debug("jsonApi:validation:output"),
+  validationError: debug("jsonApi:validation:error"),
+  errors: debug("jsonApi:errors"),
+  requestCounter: debug("jsonApi:requestCounter"),
+
+  __overrideDebugOutput: function() {}
 };
+
+debugging.__overrideDebugOutput = overrideDebugOutputHelper.bind(null, debugging);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-server",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "A config driven NodeJS framework implementing json:api",
   "keywords": [
     "jsonapi",


### PR DESCRIPTION
Add a function to the `debugging` module that allows overriding the debugging functions for each of the namespaces with a user provided function.

* [x] :heart: 
* [x] :two_hearts:
* [x] :heart: x :three: