### PR TITLE
Updated example doc for extending existing create.

### DIFF
--- a/documentation/suggested-project-structure.md
+++ b/documentation/suggested-project-structure.md
@@ -80,9 +80,9 @@ module.exports = specificEsCluster;
 // // If you want to intercept calls to extend existing behaviour:
 //
 // var baseCreate = specificEsCluster.create;
-// specificEsCluster.create = function(request, callback) {
+// specificEsCluster.create = function(request, newResource, callback) {
 //   // tweak something?
-//   baseCreate.call(specificEsCluster, request, function(err, result) {
+//   baseCreate.call(specificEsCluster, request, newResource, function(err, result) {
 //     // tweak something else?
 //     return callback(err, result);
 //   });


### PR DESCRIPTION
Example documentation for intercepting calls to extend existing behavior was using an incorrect signature, causing confusion when attempting to follow the code.