### PR TITLE
Allow SSL/TLS connections

### DIFF
--- a/documentation/configuring.md
+++ b/documentation/configuring.md
@@ -19,6 +19,40 @@ jsonApi.setConfig({
 });
 ```
 
+#### Configuring HTTPS
+
+To run over HTTPS, set the protocol to _https_ and configure the appropriate TLS settings
+
+For example: 
+
+```javascript
+var fs = require("fs");
+jsonApi.setConfig({
+  protocol: "https",
+  port: 16006,
+  tls: {
+    cert: fs.readFileSync('server.crt'),
+    key: fs.readFileSync('server.key')
+    passphrase: 'pass'
+  }
+});
+```
+or
+
+```javascript
+var fs = require("fs");
+jsonApi.setConfig({
+  protocol: "https",
+  port: 16006,
+  tls: {
+    pfx: fs.readFileSync('server.pfx'),
+    passphrase: 'pass'
+  }
+});
+```
+
+For a full set of tls options, see https://nodejs.org/api/tls.html#tls_tls_createserver_options_secureconnectionlistener
+
 #### Error Handling
 
 ```javascript

--- a/lib/jsonApi.js
+++ b/lib/jsonApi.js
@@ -107,7 +107,14 @@ jsonApi.onUncaughtException = function(errHandler) {
 
 jsonApi.start = function() {
   routes.register();
-  router.listen(jsonApi._apiConfig.port);
+  var serverFactory = function(app) {
+      if (jsonApi._apiConfig.protocol === 'https') {
+        return require('https').createServer(jsonApi._apiConfig.tls || {}, app);
+      } else {
+        return require('http').createServer(app);
+      }
+  };
+  router.listen(jsonApi._apiConfig.port, serverFactory);
 };
 
 jsonApi.close = function() {

--- a/lib/jsonApi.js
+++ b/lib/jsonApi.js
@@ -108,10 +108,10 @@ jsonApi.onUncaughtException = function(errHandler) {
 jsonApi.start = function() {
   routes.register();
   var serverFactory = function(app) {
-      if (jsonApi._apiConfig.protocol === 'https') {
-        return require('https').createServer(jsonApi._apiConfig.tls || {}, app);
+      if (jsonApi._apiConfig.protocol === "https") {
+        return require("https").createServer(jsonApi._apiConfig.tls || {}, app);
       } else {
-        return require('http').createServer(app);
+        return require("http").createServer(app);
       }
   };
   router.listen(jsonApi._apiConfig.port, serverFactory);

--- a/lib/jsonApi.js
+++ b/lib/jsonApi.js
@@ -107,14 +107,7 @@ jsonApi.onUncaughtException = function(errHandler) {
 
 jsonApi.start = function() {
   routes.register();
-  var serverFactory = function(app) {
-      if (jsonApi._apiConfig.protocol === "https") {
-        return require("https").createServer(jsonApi._apiConfig.tls || {}, app);
-      } else {
-        return require("http").createServer(app);
-      }
-  };
-  router.listen(jsonApi._apiConfig.port, serverFactory);
+  router.listen(jsonApi._apiConfig.port);
 };
 
 jsonApi.close = function() {

--- a/lib/router.js
+++ b/lib/router.js
@@ -78,9 +78,10 @@ app.route("*").all(function(req, res, next) {
   next();
 });
 
-router.listen = function(port) {
+router.listen = function(port, serverFactory) {
   if (!server) {
-    server = app.listen(port);
+    server = serverFactory(app);
+    server.listen(port);
   }
 };
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -78,9 +78,14 @@ app.route("*").all(function(req, res, next) {
   next();
 });
 
-router.listen = function(port, serverFactory) {
+router.listen = function(port) {
+
   if (!server) {
-    server = serverFactory(app);
+    if (jsonApi._apiConfig.protocol === "https") {
+      server = require("https").createServer(jsonApi._apiConfig.tls || {}, app);
+    } else {
+      server = require("http").createServer(app);
+    }
     server.listen(port);
   }
 };


### PR DESCRIPTION
It's currently possible to set the protocol in config, like:

    jsonApi.setConfig({
      protocol: "https"
    });

This builds the urls in the api responses with 'https' as the url scheme.  It does not host the server with that protocol.

In my project, I want to use jsonapi-server over https.  I propose this change to allow the creation of an https server with provided tls config.  See:

- https://nodejs.org/api/https.html#https_https_createserver_options_requestlistener
- https://nodejs.org/api/tls.html#tls_tls_createserver_options_secureconnectionlistener
