### PR TITLE
Unable to patch relationships on resources with required attributes

### DIFF
--- a/example/resources/comments.js
+++ b/example/resources/comments.js
@@ -8,7 +8,7 @@ jsonApi.define({
   handlers: commentHandler,
   searchParams: { },
   attributes: {
-    body: jsonApi.Joi.string()
+    body: jsonApi.Joi.string().required()
       .description("The tag name")
       .example("Summer"),
     timestamp: jsonApi.Joi.string().regex(/^[12]\d\d\d-[01]\d-[0123]\d$/)

--- a/lib/routes/updateRelation.js
+++ b/lib/routes/updateRelation.js
@@ -4,7 +4,8 @@ var updateRelationRoute = module.exports = { };
 
 var async = require("async");
 var _ = {
-  assign: require("lodash.assign")
+  assign: require("lodash.assign"),
+  pick: require("lodash.pick")
 };
 var helper = require("./helper.js");
 var router = require("../router.js");
@@ -38,7 +39,8 @@ updateRelationRoute.register = function() {
           type: request.params.type
         });
         theirResource[request.params.relation] = theirs;
-        helper.validate(theirResource, resourceConfig.onCreate, callback);
+        var validator = _.pick(resourceConfig.onCreate, [ "id", "type", request.params.relation]);
+        helper.validate(theirResource, validator, callback);
       },
       function(callback) {
         resourceConfig.handlers.update(request, theirResource, callback);

--- a/test/patch-resource-id.js
+++ b/test/patch-resource-id.js
@@ -61,7 +61,7 @@ describe("Testing jsonapi-server", function() {
             }
           })
         };
-        helpers.request(data, function(err, res, json) {
+        request(data, function(err, res, json) {
           assert.equal(err, null);
           json = helpers.validateError(json);
           assert.equal(res.statusCode, "403", "Expecting 403");
@@ -200,7 +200,7 @@ describe("Testing jsonapi-server", function() {
             }
           })
         };
-        helpers.request(data, function(err, res, json) {
+        request(data, function(err, res, json) {
           assert.equal(err, null);
           json = helpers.validateJson(json);
 
@@ -292,7 +292,7 @@ describe("Testing jsonapi-server", function() {
             }
           })
         };
-        helpers.request(data, function(err, res, json) {
+        request(data, function(err, res, json) {
           assert.equal(err, null);
           json = helpers.validateJson(json);
 


### PR DESCRIPTION
Addresses #141 - When patching a resources relationship, we should only be validating the named relationship that is being mutated. I've adjusted the example server to reflect the bug, fixed the issue, and the test suite is passing again.