### PR TITLE
Error when interacting with broken resources

### DIFF
--- a/lib/routes/find.js
+++ b/lib/routes/find.js
@@ -36,6 +36,14 @@ findRoute.register = function() {
         responseHelper._enforceSchemaOnObject(resource, resourceConfig.attributes, callback);
       },
       function(sanitisedData, callback) {
+        if (!sanitisedData) {
+          return callback({
+            status: "404",
+            code: "EVERSION",
+            title: "Resource is not valid",
+            detail: "The requested resource does not conform to the API specification. This is usually the result of a versioning change."
+          });
+        }
         response = responseHelper._generateResponse(request, resourceConfig, sanitisedData);
         response.included = [ ];
         postProcess.handle(request, response, callback);

--- a/lib/routes/relationships.js
+++ b/lib/routes/relationships.js
@@ -44,6 +44,14 @@ relationshipsRoute.register = function() {
         responseHelper._enforceSchemaOnObject(resource, resourceConfig.attributes, callback);
       },
       function(sanitisedData, callback) {
+        if (!sanitisedData) {
+          return callback({
+            status: "404",
+            code: "EVERSION",
+            title: "Resource is not valid",
+            detail: "The requested resource does not conform to the API specification. This is usually the result of a versioning change."
+          });
+        }
         sanitisedData = sanitisedData.relationships[request.params.relation].data;
         response = responseHelper._generateResponse(request, resourceConfig, sanitisedData);
         callback();


### PR DESCRIPTION
This addresses #142 - If we pull a resource out of a handler and it doesn't validate, we won't respond with it. In that case, we should respond with a sensible error message saying "Sorry, this resource exists, but its fundamentally broken. We can't provide you with the resource because it won't conform to your expectations."