### PR TITLE
Clone all objects passing in-to and out-of the in memory store

### DIFF
--- a/lib/MemoryHandler.js
+++ b/lib/MemoryHandler.js
@@ -36,7 +36,7 @@ MemoryStore.prototype.search = function(request, callback) {
   if (request.params.page) {
     results = results.slice(request.params.page.offset, request.params.page.offset + request.params.page.limit);
   }
-  return callback(null, this._clone(results), resultCount);
+  return callback(null, MemoryStore._clone(results), resultCount);
 };
 
 /**
@@ -59,7 +59,7 @@ MemoryStore.prototype.find = function(request, callback) {
   }
 
   // Return the requested resource
-  return callback(null, this._clone(theResource));
+  return callback(null, MemoryStore._clone(theResource));
 };
 
 /**
@@ -67,10 +67,8 @@ MemoryStore.prototype.find = function(request, callback) {
  */
 MemoryStore.prototype.create = function(request, newResource, callback) {
   // Check to see if the ID already exists
-  var matches = resources[request.params.type].filter(function(resource) {
-    return resource.id === newResource.id;
-  }).length;
-  if (matches > 0) {
+  var index = MemoryStore._indexOf(resources[request.params.type], newResource);
+  if (index !== -1) {
     return callback({
       status: "403",
       code: "EFORBIDDEN",
@@ -81,7 +79,7 @@ MemoryStore.prototype.create = function(request, newResource, callback) {
   // Push the newResource into our in-memory store.
   resources[request.params.type].push(newResource);
   // Return the newly created resource
-  return callback(null, this._clone(newResource));
+  return callback(null, MemoryStore._clone(newResource));
 };
 
 /**
@@ -93,13 +91,8 @@ MemoryStore.prototype.delete = function(request, callback) {
     if (err) return callback(err);
 
     // Remove the resource from the in-memory store.
-    resources[request.params.type].some(function(resource, index) {
-      var match = resource.id === theResource.id;
-      if (match) {
-        resources[request.params.type].splice(index, 1);
-      }
-      return match;
-    });
+    var index = MemoryStore._indexOf(resources[request.params.type], theResource);
+    resources[request.params.type].splice(index, 1);
 
     // Return with no error
     return callback();
@@ -120,16 +113,11 @@ MemoryStore.prototype.update = function(request, partialResource, callback) {
     theResource = _.assign(theResource, partialResource);
 
     // Push the newly updated resource back into the in-memory store
-    resources[request.params.type].some(function(resource, index) {
-      var match = resource.id === theResource.id;
-      if (match) {
-        resources[request.params.type][index] = theResource;
-      }
-      return match;
-    });
+    var index = MemoryStore._indexOf(resources[request.params.type], theResource);
+    resources[request.params.type][index] = theResource;
 
     // Return the newly updated resource
-    return callback(null, self._clone(theResource));
+    return callback(null, MemoryStore._clone(theResource));
   });
 };
 
@@ -158,6 +146,13 @@ MemoryStore.prototype._sortList = function(request, list) {
   });
 };
 
-MemoryStore.prototype._clone = function(obj) {
+MemoryStore._clone = function(obj) {
   return JSON.parse(JSON.stringify(obj));
+};
+
+MemoryStore._indexOf = function(list, obj) {
+  for (var i in list) {
+    if (list[i].id === obj.id) return i;
+  }
+  return -1;
 };

--- a/lib/MemoryHandler.js
+++ b/lib/MemoryHandler.js
@@ -36,7 +36,7 @@ MemoryStore.prototype.search = function(request, callback) {
   if (request.params.page) {
     results = results.slice(request.params.page.offset, request.params.page.offset + request.params.page.limit);
   }
-  return callback(null, results, resultCount);
+  return callback(null, this._clone(results), resultCount);
 };
 
 /**
@@ -59,17 +59,29 @@ MemoryStore.prototype.find = function(request, callback) {
   }
 
   // Return the requested resource
-  return callback(null, theResource);
+  return callback(null, this._clone(theResource));
 };
 
 /**
-  Create (store) a new resource give a resource type and an object.
+  Create (store) a new resource given a resource type and an object.
  */
 MemoryStore.prototype.create = function(request, newResource, callback) {
+  // Check to see if the ID already exists
+  var matches = resources[request.params.type].filter(function(resource) {
+    return resource.id === newResource.id;
+  }).length;
+  if (matches > 0) {
+    return callback({
+      status: "403",
+      code: "EFORBIDDEN",
+      title: "Requested resource already exists",
+      detail: "The requested resource already exists of type " + request.params.type + " with id " + request.params.id
+    });
+  }
   // Push the newResource into our in-memory store.
   resources[request.params.type].push(newResource);
   // Return the newly created resource
-  return callback(null, newResource);
+  return callback(null, this._clone(newResource));
 };
 
 /**
@@ -80,9 +92,14 @@ MemoryStore.prototype.delete = function(request, callback) {
   this.find(request, function(err, theResource) {
     if (err) return callback(err);
 
-    // Remove the resource from the in-meory store.
-    var resourceIndex = resources[request.params.type].indexOf(theResource);
-    resources[request.params.type].splice(resourceIndex, 1);
+    // Remove the resource from the in-memory store.
+    resources[request.params.type].some(function(resource, index) {
+      var match = resource.id === theResource.id;
+      if (match) {
+        resources[request.params.type].splice(index, 1);
+      }
+      return match;
+    });
 
     // Return with no error
     return callback();
@@ -94,18 +111,25 @@ MemoryStore.prototype.delete = function(request, callback) {
   partialResource contains a subset of changes that need to be merged over the original.
  */
 MemoryStore.prototype.update = function(request, partialResource, callback) {
+  var self = this;
   // Find the requested resource
-  this.find(request, function(err, theResource) {
+  self.find(request, function(err, theResource) {
     if (err) return callback(err);
 
     // Merge the partialResource over the original
     theResource = _.assign(theResource, partialResource);
 
     // Push the newly updated resource back into the in-memory store
-    resources[request.params.type][request.params.id] = theResource;
+    resources[request.params.type].some(function(resource, index) {
+      var match = resource.id === theResource.id;
+      if (match) {
+        resources[request.params.type][index] = theResource;
+      }
+      return match;
+    });
 
     // Return the newly updated resource
-    return callback(null, theResource);
+    return callback(null, self._clone(theResource));
   });
 };
 
@@ -132,4 +156,8 @@ MemoryStore.prototype._sortList = function(request, list) {
       return 0;
     }
   });
+};
+
+MemoryStore.prototype._clone = function(obj) {
+  return JSON.parse(JSON.stringify(obj));
 };

--- a/lib/MemoryHandler.js
+++ b/lib/MemoryHandler.js
@@ -104,9 +104,8 @@ MemoryStore.prototype.delete = function(request, callback) {
   partialResource contains a subset of changes that need to be merged over the original.
  */
 MemoryStore.prototype.update = function(request, partialResource, callback) {
-  var self = this;
   // Find the requested resource
-  self.find(request, function(err, theResource) {
+  this.find(request, function(err, theResource) {
     if (err) return callback(err);
 
     // Merge the partialResource over the original


### PR DESCRIPTION
We've had some issues with stubbing journey tests via the memory handler, and they boil down to how the memory handler doesn't clone objects passing through it. This PR ensures all objects get cloned to allow us to mutate resources without effecting the data in the store.