### PR TITLE
Expose ExpressJS server

### DIFF
--- a/documentation/configuring.md
+++ b/documentation/configuring.md
@@ -23,7 +23,7 @@ jsonApi.setConfig({
 
 To run over HTTPS, set the protocol to _https_ and configure the appropriate TLS settings
 
-For example: 
+For example:
 
 ```javascript
 var fs = require("fs");
@@ -89,4 +89,14 @@ To gracefully shutdown the service, you can call `.close()`. This will inform al
 
 ```javascript
 jsonApi.close();
+```
+
+#### Gaining access to the Express server
+
+Whilst interfering with the routing layer of jsonapi-server is not recommended (any modifications you make will go against the specification) I can appreciate the needs of businesses and the need to get stuff done. There is therefore an accessor to enable a consumer of jsonapi-server to inject their own custom routes / middleware BEFORE the json:api routes and middleware are applied.
+
+```javascript
+var app = jsonApi.getExpressServer();
+app.use(someMiddleware);
+jsonApi.start() // this line applies the json:api routing and starts the service
 ```

--- a/example/server.js
+++ b/example/server.js
@@ -56,7 +56,7 @@ jsonApi.onUncaughtException(function(request, error) {
 
 // If we're using the example server for the test suite,
 // wait for the tests to call .start();
-if (typeof describe !== undefined) {
+if (typeof describe === "undefined") {
   jsonApi.start();
 }
 server.start = jsonApi.start;

--- a/example/server.js
+++ b/example/server.js
@@ -54,6 +54,11 @@ jsonApi.onUncaughtException(function(request, error) {
   }));
 });
 
-jsonApi.start();
+// If we're using the example server for the test suite,
+// wait for the tests to call .start();
+if (typeof describe !== undefined) {
+  jsonApi.start();
+}
 server.start = jsonApi.start;
 server.close = jsonApi.close;
+server.getExpressServer = jsonApi.getExpressServer;

--- a/lib/jsonApi.js
+++ b/lib/jsonApi.js
@@ -106,7 +106,12 @@ jsonApi.onUncaughtException = function(errHandler) {
   jsonApi._errHandler = errHandler;
 };
 
+jsonApi.getExpressServer = function() {
+  return router.getExpressServer();
+};
+
 jsonApi.start = function() {
+  router.applyMiddleware();
   routes.register();
   router.listen(jsonApi._apiConfig.port);
 };

--- a/lib/router.js
+++ b/lib/router.js
@@ -18,19 +18,6 @@ var url = require("url");
 
 
 router.applyMiddleware = function() {
-  app.use(bodyParser.json());
-  app.use(bodyParser.urlencoded({ extended: true }));
-  app.use(cookieParser());
-  app.disable("x-powered-by");
-  app.disable("etag");
-
-  var requestId = 0;
-  app.route("*").all(function(req, res, next) {
-    debug.requestCounter(requestId++, req.method, req.url);
-    if (requestId > 1000) requestId = 0;
-    next();
-  });
-
   app.use(function(req, res, next) {
     if (!req.headers["content-type"] && !req.headers.accept) return next();
 
@@ -78,6 +65,19 @@ router.applyMiddleware = function() {
     }
 
     return next();
+  });
+
+  app.use(bodyParser.json());
+  app.use(bodyParser.urlencoded({ extended: true }));
+  app.use(cookieParser());
+  app.disable("x-powered-by");
+  app.disable("etag");
+
+  var requestId = 0;
+  app.route("*").all(function(req, res, next) {
+    debug.requestCounter(requestId++, req.method, req.url);
+    if (requestId > 1000) requestId = 0;
+    next();
   });
 };
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -16,67 +16,70 @@ var debug = require("./debugging.js");
 var responseHelper = require("./responseHelper.js");
 var url = require("url");
 
-app.use(function(req, res, next) {
-  if (!req.headers["content-type"] && !req.headers.accept) return next();
 
-  if (req.headers["content-type"]) {
-    // 415 Unsupported Media Type
-    if (req.headers["content-type"].match(/^application\/vnd\.api\+json;.+$/)) {
-      return res.status(415).end();
-    }
+router.applyMiddleware = function() {
+  app.use(bodyParser.json());
+  app.use(bodyParser.urlencoded({ extended: true }));
+  app.use(cookieParser());
+  app.disable("x-powered-by");
+  app.disable("etag");
 
-    // Convert "application/vnd.api+json" content type to "application/json".
-    // This enables the express body parser to correctly parse the JSON payload.
-    if (req.headers["content-type"].match(/^application\/vnd\.api\+json$/)) {
-      req.headers["content-type"] = "application/json";
-    }
-  }
-
-  if (req.headers.accept) {
-    // 406 Not Acceptable
-    var matchingTypes = req.headers.accept.split(/, ?/);
-    matchingTypes = matchingTypes.filter(function(mediaType) {
-      // Accept application/*, */vnd.api+json, */* and the correct JSON:API type.
-      return mediaType.match(/^(\*|application)\/(\*|vnd\.api\+json)$/) || mediaType.match(/\*\/\*/);
-    });
-
-    if (matchingTypes.length === 0) {
-      return res.status(406).end();
-    }
-  }
-
-  return next();
-});
-
-app.use(function(req, res, next) {
-  res.set({
-    "Content-Type": "application/vnd.api+json",
-    "Access-Control-Allow-Origin": "*",
-    "Access-Control-Allow-Methods": "GET, POST, PATCH, DELETE, OPTIONS",
-    "Access-Control-Allow-Headers": req.headers["access-control-request-headers"] || "",
-    "Cache-Control": "private, must-revalidate, max-age=0",
-    "Expires": "Thu, 01 Jan 1970 00:00:00"
+  var requestId = 0;
+  app.route("*").all(function(req, res, next) {
+    debug.requestCounter(requestId++, req.method, req.url);
+    if (requestId > 1000) requestId = 0;
+    next();
   });
 
-  if (req.method === "OPTIONS") {
-    return res.status(204).end();
-  }
+  app.use(function(req, res, next) {
+    if (!req.headers["content-type"] && !req.headers.accept) return next();
 
-  return next();
-});
+    if (req.headers["content-type"]) {
+      // 415 Unsupported Media Type
+      if (req.headers["content-type"].match(/^application\/vnd\.api\+json;.+$/)) {
+        return res.status(415).end();
+      }
 
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({ extended: true }));
-app.use(cookieParser());
-app.disable("x-powered-by");
-app.disable("etag");
+      // Convert "application/vnd.api+json" content type to "application/json".
+      // This enables the express body parser to correctly parse the JSON payload.
+      if (req.headers["content-type"].match(/^application\/vnd\.api\+json$/)) {
+        req.headers["content-type"] = "application/json";
+      }
+    }
 
-var requestId = 0;
-app.route("*").all(function(req, res, next) {
-  debug.requestCounter(requestId++, req.method, req.url);
-  if (requestId > 1000) requestId = 0;
-  next();
-});
+    if (req.headers.accept) {
+      // 406 Not Acceptable
+      var matchingTypes = req.headers.accept.split(/, ?/);
+      matchingTypes = matchingTypes.filter(function(mediaType) {
+        // Accept application/*, */vnd.api+json, */* and the correct JSON:API type.
+        return mediaType.match(/^(\*|application)\/(\*|vnd\.api\+json)$/) || mediaType.match(/\*\/\*/);
+      });
+
+      if (matchingTypes.length === 0) {
+        return res.status(406).end();
+      }
+    }
+
+    return next();
+  });
+
+  app.use(function(req, res, next) {
+    res.set({
+      "Content-Type": "application/vnd.api+json",
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, POST, PATCH, DELETE, OPTIONS",
+      "Access-Control-Allow-Headers": req.headers["access-control-request-headers"] || "",
+      "Cache-Control": "private, must-revalidate, max-age=0",
+      "Expires": "Thu, 01 Jan 1970 00:00:00"
+    });
+
+    if (req.method === "OPTIONS") {
+      return res.status(204).end();
+    }
+
+    return next();
+  });
+};
 
 router.listen = function(port) {
 
@@ -180,4 +183,8 @@ router._getParams = function(req) {
 
 router.sendResponse = function(res, payload, httpCode) {
   res.status(httpCode).json(payload);
+};
+
+router.getExpressServer = function() {
+  return app;
 };

--- a/test/404.js
+++ b/test/404.js
@@ -37,6 +37,10 @@ describe("Testing jsonapi-server", function() {
   });
 
   before(function() {
+    jsonApiTestServer.getExpressServer().use(function(req, res, next) {
+      console.log("YAY");
+      return next();
+    });
     jsonApiTestServer.start();
   });
   after(function() {

--- a/test/404.js
+++ b/test/404.js
@@ -37,10 +37,6 @@ describe("Testing jsonapi-server", function() {
   });
 
   before(function() {
-    jsonApiTestServer.getExpressServer().use(function(req, res, next) {
-      console.log("YAY");
-      return next();
-    });
     jsonApiTestServer.start();
   });
   after(function() {


### PR DESCRIPTION
Addresses #143. This PR enables us to interact with the underlying Express application before jsonapi-server touches it:

```javascript
  var app = jsonApi.getExpressServer();
  app.use(someMiddleware);
  jsonApi.start() // this line applies the json:api routing and starts the service
```

You can see this in action by changing the `before` block in `test/404.js` to something like this:
```
before(function() {
  jsonApiTestServer.getExpressServer().use(function(req, res, next) {
    console.log("Middleware just ran");
    return next();
  });
  jsonApiTestServer.start();
});
```
...and then run the test suite.

This PR also opens up the possibility of passing an existing ExpressJS app into jsonapi-server.