### PR TITLE
Mutating singular relationships via direct http route

### DIFF
--- a/lib/routes/addRelation.js
+++ b/lib/routes/addRelation.js
@@ -35,8 +35,14 @@ addRelationRoute.register = function() {
         theirResource = JSON.parse(JSON.stringify(ourResource));
 
         var theirs = request.params.data;
-        theirResource[request.params.relation] = theirResource[request.params.relation] || [ ];
-        theirResource[request.params.relation].push(theirs);
+
+        if (resourceConfig.attributes[request.params.relation]._settings.__many) {
+            theirResource[request.params.relation] = theirResource[request.params.relation] || [ ];
+            theirResource[request.params.relation].push(theirs);
+        } else {
+            theirResource[request.params.relation] = theirs;
+        }
+
         helper.validate(theirResource, resourceConfig.onCreate, callback);
       },
       function(callback) {

--- a/lib/routes/removeRelation.js
+++ b/lib/routes/removeRelation.js
@@ -34,9 +34,11 @@ removeRelationRoute.register = function() {
       function(ourResource, callback) {
         theirResource = ourResource;
 
+        var isMany = resourceConfig.attributes[request.params.relation]._settings.__many;
         var theirs = request.params.data;
-        theirResource[request.params.relation] = theirResource[request.params.relation] || [ ];
-        if (!(theirs instanceof Array)) theirs = [ theirs ];
+        if (!(theirs instanceof Array)) {
+          theirs = [ theirs ];
+        }
 
         var keys = theirResource[request.params.relation].map(function(j) {
           return j.id;
@@ -61,7 +63,13 @@ removeRelationRoute.register = function() {
               detail: "Unknown id " + someId
             });
           }
-          theirResource[request.params.relation].splice(indexOfTheirs, 1);
+          if (isMany) {
+            theirResource[request.params.relation].splice(indexOfTheirs, 1);
+          }
+        }
+
+        if (!isMany) {
+          theirResource[request.params.relation] = null;
         }
 
         helper.validate(theirResource, resourceConfig.onCreate, callback);

--- a/test/delete-resource-id-relationships-related.js
+++ b/test/delete-resource-id-relationships-related.js
@@ -81,7 +81,7 @@ describe("Testing jsonapi-server", function() {
     });
 
     describe("deleting", function() {
-      it("deletes the resource", function(done) {
+      it("deletes the resource on many()", function(done) {
         var data = {
           method: "delete",
           url: "http://localhost:16006/rest/articles/fa2a073f-8c64-4cbb-9158-b8f67a4ab9f5/relationships/tags",
@@ -119,6 +119,45 @@ describe("Testing jsonapi-server", function() {
               "id": "6ec62f6d-9f82-40c5-b4f4-279ed1765492"
             }
           ]);
+
+          done();
+        });
+      });
+    });
+
+    describe("deleting", function() {
+      it("deletes the resource on one()", function(done) {
+        var data = {
+          method: "delete",
+          url: "http://localhost:16006/rest/articles/fa2a073f-8c64-4cbb-9158-b8f67a4ab9f5/relationships/tags",
+          headers: {
+            "Content-Type": "application/vnd.api+json"
+          },
+          body: JSON.stringify({
+            "data": { "type": "tags", "id": "6ec62f6d-9f82-40c5-b4f4-279ed1765492" }
+          })
+        };
+        helpers.request(data, function(err, res, json) {
+          assert.equal(err, null);
+          json = helpers.validateJson(json);
+
+          assert.equal(res.statusCode, "200", "Expecting 200");
+
+          done();
+        });
+      });
+
+      it("new resource has changed", function(done) {
+        var url = "http://localhost:16006/rest/articles/fa2a073f-8c64-4cbb-9158-b8f67a4ab9f5/relationships/tags";
+        helpers.request({
+        method: "GET",
+        url: url
+      }, function(err, res, json) {
+          assert.equal(err, null);
+          json = helpers.validateJson(json);
+
+          assert.equal(res.statusCode, "200", "Expecting 200");
+          assert.deepEqual(json.data, [ ]);
 
           done();
         });

--- a/test/post-resource-id-relationships-related.js
+++ b/test/post-resource-id-relationships-related.js
@@ -60,7 +60,7 @@ describe("Testing jsonapi-server", function() {
       });
     });
 
-    describe("adding", function() {
+    describe("adding to a many()", function() {
       it("updates the resource", function(done) {
         var data = {
           method: "post",
@@ -106,6 +106,49 @@ describe("Testing jsonapi-server", function() {
               }
             }
           ]);
+
+          done();
+        });
+      });
+    });
+
+    describe("adding to a one()", function() {
+      it("updates the resource", function(done) {
+        var data = {
+          method: "post",
+          url: "http://localhost:16006/rest/articles/fa2a073f-8c64-4cbb-9158-b8f67a4ab9f5/relationships/author",
+          headers: {
+            "Content-Type": "application/vnd.api+json"
+          },
+          body: JSON.stringify({
+            "data": { "type": "people", "id": "cc5cca2e-0dd8-4b95-8cfc-a11230e73116" }
+          })
+        };
+        helpers.request(data, function(err, res, json) {
+          assert.equal(err, null);
+          json = helpers.validateJson(json);
+
+          assert.equal(res.statusCode, "201", "Expecting 201");
+
+          done();
+        });
+      });
+
+      it("new resource has changed", function(done) {
+        var url = "http://localhost:16006/rest/articles/fa2a073f-8c64-4cbb-9158-b8f67a4ab9f5/relationships/author";
+        helpers.request({
+          method: "GET",
+          url: url
+        }, function(err, res, json) {
+          assert.equal(err, null);
+          json = helpers.validateJson(json);
+
+          assert.equal(res.statusCode, "200", "Expecting 200");
+
+          assert.deepEqual(json.data, {
+            "type": "people",
+            "id": "cc5cca2e-0dd8-4b95-8cfc-a11230e73116"
+          });
 
           done();
         });


### PR DESCRIPTION
Addresses #144. When mutating a resources relationships on a `hasOne` relationship currently breaks in master. I've implemented the fix suggested by @jbockerstette and I've added tests to prove it now works for both POST'ing and DELETE'ing to both `hasOne` and `hasMany` relationships.