### PR TITLE
Enabling application metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ We've also written a library to ease the consumption of a json:api compliant ser
 - [Custom Handlers](documentation/handlers.md)
 - [Post Processing Examples](documentation/post-processing.md)
 - [Migrating from an existing express server](documentation/api-migration.md)
+- [Application metrics](documentation/metrics.md)
 
 ### The tl;dr
 

--- a/documentation/metrics.md
+++ b/documentation/metrics.md
@@ -1,0 +1,21 @@
+
+### Generating Application Metrics
+
+Application metrics are generated and exposed via an event emitter interface. Whenever a request has been processed and it about to be returned to the customer, a `data` event will be emitted:
+
+```javascript
+jsonApi.metrics.on("data", function(data) {
+  // send data to your metrics stack
+});
+```
+
+This is the data made available via this interface:
+```javascript
+{
+  route: "people/:id/parent",
+  verb: "GET",
+  httpCode: 200,
+  error: "Optional error message",
+  duration: 123
+}
+```

--- a/example/server.js
+++ b/example/server.js
@@ -4,6 +4,7 @@ var server = module.exports = { };
 var jsonApi = require("../.");
 var fs = require("fs");
 var path = require("path");
+var debug = require("debug");
 
 jsonApi.setConfig({
   swagger: {
@@ -52,6 +53,10 @@ jsonApi.onUncaughtException(function(request, error) {
     error: errorDetails.shift(),
     stack: errorDetails
   }));
+});
+
+jsonApi.metrics.on("data", function(data) {
+  debug("metrics")(data);
 });
 
 // If we're using the example server for the test suite,

--- a/lib/jsonApi.js
+++ b/lib/jsonApi.js
@@ -16,8 +16,10 @@ var handlerEnforcer = require("./handlerEnforcer.js");
 var pagination = require("./pagination.js");
 var routes = require("./routes");
 var url = require("url");
+var metrics = require("./metrics.js");
 
 jsonApi.Joi = ourJoi.Joi;
+jsonApi.metrics = metrics.emitter;
 jsonApi.MemoryHandler = require("./MemoryHandler");
 
 jsonApi.setConfig = function(apiConfig) {

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -1,0 +1,20 @@
+/* @flow weak */
+"use strict";
+var metrics = module.exports = { };
+
+var EventEmitter = require("events").EventEmitter;
+metrics.emitter = new EventEmitter();
+
+metrics.processResponse = function(request, httpCode, payload, duration) {
+  var route = request ? request.route.path : "invalid";
+  route = route.replace(/[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}/ig, ":id");
+  route = route.replace(/\/$/, "");
+
+  metrics.emitter.emit("data", {
+    route: route,
+    verb: request ? request.route.verb || "GET" : "GET",
+    httpCode: httpCode,
+    error: payload.errors ? payload.errors[0].title : null,
+    duration: duration || 0
+  });
+};

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -5,10 +5,18 @@ var metrics = module.exports = { };
 var EventEmitter = require("events").EventEmitter;
 metrics.emitter = new EventEmitter();
 
+metrics._replaceUUIDsInRoute = function(routeString) {
+  return routeString.replace(/[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}/ig, ":id");
+};
+
+metrics._replaceTrailingSlashesInRoute = function(routeString) {
+  return routeString.replace(/\/$/, "");
+};
+
 metrics.processResponse = function(request, httpCode, payload, duration) {
   var route = request ? request.route.path : "invalid";
-  route = route.replace(/[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}/ig, ":id");
-  route = route.replace(/\/$/, "");
+  route = metrics._replaceUUIDsInRoute(route);
+  route = metrics._replaceTrailingSlashesInRoute(route);
 
   metrics.emitter.emit("data", {
     route: route,

--- a/lib/router.js
+++ b/lib/router.js
@@ -110,7 +110,7 @@ router.bindRoute = function(config, callback) {
     var resourceConfig = jsonApi._resources[request.params.type];
     request.resourceConfig = resourceConfig;
     res._request = request;
-    res._startDate = new Date();
+    res._startDate = router._getPreciseTime();
     router.authenticate(request, res, function() {
       return callback(request, resourceConfig, res);
     });
@@ -185,10 +185,20 @@ router._getParams = function(req) {
 };
 
 router.sendResponse = function(res, payload, httpCode) {
-  metrics.processResponse(res._request, httpCode, payload, (new Date()) - res._startDate);
+  var timeDiff = router._getTimeDiff(router._getPreciseTime(), res._startDate);
+  metrics.processResponse(res._request, httpCode, payload, timeDiff);
   res.status(httpCode).json(payload);
 };
 
 router.getExpressServer = function() {
   return app;
+};
+
+router._getTimeDiff = function(a, b) {
+  return parseFloat((a - b).toFixed(2));
+};
+
+router._getPreciseTime = function() {
+  var parts = process.hrtime();
+  return (((parts[0]*1000)+(parts[1]/1000000))%10000).toFixed(2);
 };

--- a/lib/router.js
+++ b/lib/router.js
@@ -15,6 +15,7 @@ var jsonApi = require("./jsonApi.js");
 var debug = require("./debugging.js");
 var responseHelper = require("./responseHelper.js");
 var url = require("url");
+var metrics = require("./metrics.js");
 
 
 router.applyMiddleware = function() {
@@ -108,6 +109,8 @@ router.bindRoute = function(config, callback) {
     request = _.assign(request, extras);
     var resourceConfig = jsonApi._resources[request.params.type];
     request.resourceConfig = resourceConfig;
+    res._request = request;
+    res._startDate = new Date();
     router.authenticate(request, res, function() {
       return callback(request, resourceConfig, res);
     });
@@ -124,11 +127,11 @@ router.authenticate = function(request, res, callback) {
     if (!err) return callback();
 
     var errorWrapper = {
-        status: "401",
-        code: "UNAUTHORIZED",
-        title: "Authentication Failed",
-        detail: err || "You are not authorised to access this resource."
-      };
+      status: "401",
+      code: "UNAUTHORIZED",
+      title: "Authentication Failed",
+      detail: err || "You are not authorised to access this resource."
+    };
     var payload = responseHelper.generateError(request, errorWrapper);
     res.status(401).json(payload);
   });
@@ -182,6 +185,7 @@ router._getParams = function(req) {
 };
 
 router.sendResponse = function(res, payload, httpCode) {
+  metrics.processResponse(res._request, httpCode, payload, (new Date()) - res._startDate);
   res.status(httpCode).json(payload);
 };
 


### PR DESCRIPTION
This PR enables consumers of jsonapi-server to easily send data off to a metrics stack for visibility of request volumes, durations and errors.

You can preview this work by starting the example server via:
```
$ DEBUG=metrics npm start
```
or
```
$ DEBUG=metrics npm test
```