### PR TITLE
Scrap sub-milliscond accuracy from metrics

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -110,7 +110,7 @@ router.bindRoute = function(config, callback) {
     var resourceConfig = jsonApi._resources[request.params.type];
     request.resourceConfig = resourceConfig;
     res._request = request;
-    res._startDate = router._getPreciseTime();
+    res._startDate = new Date();
     router.authenticate(request, res, function() {
       return callback(request, resourceConfig, res);
     });
@@ -185,20 +185,11 @@ router._getParams = function(req) {
 };
 
 router.sendResponse = function(res, payload, httpCode) {
-  var timeDiff = router._getTimeDiff(router._getPreciseTime(), res._startDate);
+  var timeDiff = (new Date()) - res._startDate;
   metrics.processResponse(res._request, httpCode, payload, timeDiff);
   res.status(httpCode).json(payload);
 };
 
 router.getExpressServer = function() {
   return app;
-};
-
-router._getTimeDiff = function(a, b) {
-  return parseFloat((a - b).toFixed(2));
-};
-
-router._getPreciseTime = function() {
-  var parts = process.hrtime();
-  return (((parts[0]*1000)+(parts[1]/1000000))%10000).toFixed(2);
 };


### PR DESCRIPTION
Sub-millisecond accuracy seems to lead to inconsistent readings. Lets go back to using regular `Date()`s.