### PR TITLE
Delete one relationship

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- 2016-07-05 - v1.15.1
+- 2016-07-05 - Fixed bug when deleting singular relationships via deep urls
 - 2016-06-28 - v1.15.0
 - 2016-06-28 - Scrap sub-millisecond accuracy on metrics
 - 2016-06-27 - v1.14.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 - 2016-07-05 - v1.15.1
 - 2016-07-05 - Fixed bug when deleting singular relationships via deep urls
+- 2016-07-05 - Added warning messages to test suite to warn when handlers don't filter
 - 2016-06-28 - v1.15.0
 - 2016-06-28 - Scrap sub-millisecond accuracy on metrics
 - 2016-06-27 - v1.14.0

--- a/lib/routes/removeRelation.js
+++ b/lib/routes/removeRelation.js
@@ -35,17 +35,19 @@ removeRelationRoute.register = function() {
         theirResource = ourResource;
 
         var isMany = resourceConfig.attributes[request.params.relation]._settings.__many;
+        var isOne = resourceConfig.attributes[request.params.relation]._settings.__one;
+        var relationType = isMany || isOne;
         var theirs = request.params.data;
         if (!(theirs instanceof Array)) {
           theirs = [ theirs ];
         }
 
-        var keys = theirResource[request.params.relation].map(function(j) {
+        var keys = [].concat(theirResource[request.params.relation]).map(function(j) {
           return j.id;
         });
 
         for (var i = 0; i < theirs.length; i++) {
-          if (theirs[i].type !== request.params.relation) {
+          if (theirs[i].type !== relationType) {
             return callback({
               status: "403",
               code: "EFORBIDDEN",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-server",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "A config driven NodeJS framework implementing json:api",
   "keywords": [
     "jsonapi",

--- a/test/delete-resource-id-relationships-related.js
+++ b/test/delete-resource-id-relationships-related.js
@@ -129,12 +129,12 @@ describe("Testing jsonapi-server", function() {
       it("deletes the resource on one()", function(done) {
         var data = {
           method: "delete",
-          url: "http://localhost:16006/rest/articles/fa2a073f-8c64-4cbb-9158-b8f67a4ab9f5/relationships/tags",
+          url: "http://localhost:16006/rest/articles/fa2a073f-8c64-4cbb-9158-b8f67a4ab9f5/relationships/author",
           headers: {
             "Content-Type": "application/vnd.api+json"
           },
           body: JSON.stringify({
-            "data": { "type": "tags", "id": "6ec62f6d-9f82-40c5-b4f4-279ed1765492" }
+            "data": { "type": "people", "id": "ad3aa89e-9c5b-4ac9-a652-6670f9f27587" }
           })
         };
         helpers.request(data, function(err, res, json) {
@@ -148,7 +148,7 @@ describe("Testing jsonapi-server", function() {
       });
 
       it("new resource has changed", function(done) {
-        var url = "http://localhost:16006/rest/articles/fa2a073f-8c64-4cbb-9158-b8f67a4ab9f5/relationships/tags";
+        var url = "http://localhost:16006/rest/articles/fa2a073f-8c64-4cbb-9158-b8f67a4ab9f5/relationships/author";
         helpers.request({
         method: "GET",
         url: url
@@ -157,7 +157,28 @@ describe("Testing jsonapi-server", function() {
           json = helpers.validateJson(json);
 
           assert.equal(res.statusCode, "200", "Expecting 200");
-          assert.deepEqual(json.data, [ ]);
+          assert.deepEqual(json.data, null);
+
+          done();
+        });
+      });
+
+      it("restore relation", function(done) {
+        var data = {
+          method: "post",
+          url: "http://localhost:16006/rest/articles/fa2a073f-8c64-4cbb-9158-b8f67a4ab9f5/relationships/author",
+          headers: {
+            "Content-Type": "application/vnd.api+json"
+          },
+          body: JSON.stringify({
+            "data": { "type": "people", "id": "ad3aa89e-9c5b-4ac9-a652-6670f9f27587" }
+          })
+        };
+        helpers.request(data, function(err, res, json) {
+          assert.equal(err, null);
+          json = helpers.validateJson(json);
+
+          assert.equal(res.statusCode, "201", "Expecting 201");
 
           done();
         });


### PR DESCRIPTION
Fixes #164. I thought we'd squashed this one in #154 but it looks like one of the tests wasn't quite right and thus wasn't exercising the code properly.

This PR also includes some additional test suite warnings for use with other data handlers to warn if the data layer filtering isn't functioning.