### PR TITLE
Updating eslintrc following major version bump

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,5 @@
 {
+  "extends": "eslint:recommended",
   "globals": {
   },
   "env": {
@@ -7,6 +8,7 @@
   },
   "rules": {
     "no-underscore-dangle": [ 0 ],
-    "curly": [2, "multi-line"]
+    "curly": [2, "multi-line"],
+    "no-console": [ 0 ]
   }
 }


### PR DESCRIPTION
When we last bumped the version of eslint and jumped major versions we forgot to opt-in to the recommended ruleset. This PR fixes up our config file to ensure we get the most value out of eslint.