### PR TITLE
Moving CORS heads up the middleware chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- 2016-07-06 - v1.15.2
+- 2016-07-06 - CORS headers are now applier further up the middleware chain
 - 2016-07-05 - v1.15.1
 - 2016-07-05 - Fixed bug when deleting singular relationships via deep urls
 - 2016-07-05 - Added warning messages to test suite to warn when handlers don't filter

--- a/lib/router.js
+++ b/lib/router.js
@@ -20,6 +20,23 @@ var metrics = require("./metrics.js");
 
 router.applyMiddleware = function() {
   app.use(function(req, res, next) {
+    res.set({
+      "Content-Type": "application/vnd.api+json",
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, POST, PATCH, DELETE, OPTIONS",
+      "Access-Control-Allow-Headers": req.headers["access-control-request-headers"] || "",
+      "Cache-Control": "private, must-revalidate, max-age=0",
+      "Expires": "Thu, 01 Jan 1970 00:00:00"
+    });
+
+    if (req.method === "OPTIONS") {
+      return res.status(204).end();
+    }
+
+    return next();
+  });
+
+  app.use(function(req, res, next) {
     if (!req.headers["content-type"] && !req.headers.accept) return next();
 
     if (req.headers["content-type"]) {
@@ -46,23 +63,6 @@ router.applyMiddleware = function() {
       if (matchingTypes.length === 0) {
         return res.status(406).end();
       }
-    }
-
-    return next();
-  });
-
-  app.use(function(req, res, next) {
-    res.set({
-      "Content-Type": "application/vnd.api+json",
-      "Access-Control-Allow-Origin": "*",
-      "Access-Control-Allow-Methods": "GET, POST, PATCH, DELETE, OPTIONS",
-      "Access-Control-Allow-Headers": req.headers["access-control-request-headers"] || "",
-      "Cache-Control": "private, must-revalidate, max-age=0",
-      "Expires": "Thu, 01 Jan 1970 00:00:00"
-    });
-
-    if (req.method === "OPTIONS") {
-      return res.status(204).end();
     }
 
     return next();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-server",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "description": "A config driven NodeJS framework implementing json:api",
   "keywords": [
     "jsonapi",


### PR DESCRIPTION
We're seeing some errors in the `jsonapi-client` test suite via saucelabs whereby some errors occur before the CORS headers are applied. This PR ensures CORS headers are the first thing to be applied to the response.

You can see examples of input validation errors occurring before CORS headers are set in this build with the debugging enabled:
https://travis-ci.org/holidayextras/jsonapi-client/jobs/142731040 

```
      ✓ throws an error when adding a non-resource
  express:router dispatching OPTIONS /rest/photos/72695cbd-e9ef-44f6-85e0-0dbc06a269e8 +8ms
  express:router query  : /rest/photos/72695cbd-e9ef-44f6-85e0-0dbc06a269e8 +0ms
  express:router expressInit  : /rest/photos/72695cbd-e9ef-44f6-85e0-0dbc06a269e8 +1ms
  express:router <anonymous>  : /rest/photos/72695cbd-e9ef-44f6-85e0-0dbc06a269e8 +0ms
  express:router <anonymous>  : /rest/photos/72695cbd-e9ef-44f6-85e0-0dbc06a269e8 +0ms
  express:router dispatching PATCH /rest/photos/72695cbd-e9ef-44f6-85e0-0dbc06a269e8 +2ms
  express:router query  : /rest/photos/72695cbd-e9ef-44f6-85e0-0dbc06a269e8 +0ms
  express:router expressInit  : /rest/photos/72695cbd-e9ef-44f6-85e0-0dbc06a269e8 +0ms
  express:router <anonymous>  : /rest/photos/72695cbd-e9ef-44f6-85e0-0dbc06a269e8 +0ms
ERROR LOG: 'Transport Error: {"crossDomain":true,"method":"PATCH","url":"http://localhost:16006/rest/photos/72695cbd-e9ef-44f6-85e0-0dbc06a269e8"}'
      ✗ removing the linked resource works fine
```
The OPTIONS pre-flight request fires, it responds, the real request fires which doesn't get any CORS headers causing the test to fail with a CORS error.