### PR TITLE
Provide error text to help debug HTTP 415s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- 2016-07-06 - v1.15.3
+- 2016-07-06 - Provide text error to help debug HTTP 415s
 - 2016-07-06 - v1.15.2
 - 2016-07-06 - CORS headers are now applier further up the middleware chain
 - 2016-07-05 - v1.15.1

--- a/lib/router.js
+++ b/lib/router.js
@@ -42,7 +42,7 @@ router.applyMiddleware = function() {
     if (req.headers["content-type"]) {
       // 415 Unsupported Media Type
       if (req.headers["content-type"].match(/^application\/vnd\.api\+json;.+$/)) {
-        return res.status(415).end();
+        return res.status(415).end("HTTP 415 Unsupported Media Type - " + req.headers["content-type"]);
       }
 
       // Convert "application/vnd.api+json" content type to "application/json".

--- a/lib/router.js
+++ b/lib/router.js
@@ -42,7 +42,7 @@ router.applyMiddleware = function() {
     if (req.headers["content-type"]) {
       // 415 Unsupported Media Type
       if (req.headers["content-type"].match(/^application\/vnd\.api\+json;.+$/)) {
-        return res.status(415).end("HTTP 415 Unsupported Media Type - " + req.headers["content-type"]);
+        return res.status(415).end("HTTP 415 Unsupported Media Type - [" + req.headers["content-type"] + "]");
       }
 
       // Convert "application/vnd.api+json" content type to "application/json".

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-server",
-  "version": "1.15.2",
+  "version": "1.15.3",
   "description": "A config driven NodeJS framework implementing json:api",
   "keywords": [
     "jsonapi",


### PR DESCRIPTION
We're having issues with conflicting information in the `jsonapi-client` cross browser tests whereby we're getting HTTP 415's but it's not clear why. This PR should help us identify and fix the issue.

https://travis-ci.org/holidayextras/jsonapi-client/jobs/142740375

I'm running in to some interesting stuff on Travis at the moment with some Karma tests and content-type headers.. 

 ```
 ERROR LOG: 'Transport Error: {"original":null,"response":{"req":{"method":"POST","url":"http://localhost:16006/rest/people","data":{"data":{"id":null,"type":"people","attributes":{},"relationships":{}}}},"xhr":{},"text":"","statusText":"Unsupported Media Type","statusCode":415,"status":415,"statusType":4,"info":false,"ok":false,"clientError":true,"serverError":false,"error":{"status":415,"method":"POST","url":"http://localhost:16006/rest/people"},"accepted":false,"noContent":false,"badRequest":false,"unauthorized":false,"notAcceptable":false,"notFound":false,"forbidden":false,"headers":{"content-type":"application/vnd.api+json","cache-control":"private, must-revalidate, max-age=0","expires":"Thu, 01 Jan 1970 00:00:00"},"header":{"content-type":"application/vnd.api+json","cache-control":"private, must-revalidate, max-age=0","expires":"Thu, 01 Jan 1970 00:00:00"},"type":"application/vnd.api+json","body":null},"status":415}'
```

These only happen on Travis + SauceLabs + VPN tunnel... I'm basically getting a HTTP 415 which originates from this:
```
// 415 Unsupported Media Type
if (req.headers["content-type"].match(/^application\/vnd\.api\+json;.+$/)) {
  return res.status(415).end();
}
```

However the Karma log that I've pasted above states:
```
"header":{
  "content-type":"application/vnd.api+json",
```
...which doesn't match the regex in the above code?