### PR TITLE
Prevent express from appending the charset to the content-type header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- 2016-07-06 - v1.15.4
+- 2016-07-06 - Prevent express from appending the charset to the content-type header
 - 2016-07-06 - v1.15.3
 - 2016-07-06 - Provide text error to help debug HTTP 415s
 - 2016-07-06 - v1.15.2

--- a/lib/rerouter.js
+++ b/lib/rerouter.js
@@ -29,13 +29,14 @@ rerouter.route = function(newRequest, callback) {
       res.httpCode = httpCode;
       return res;
     },
-    json: function(payload) {
+    end: function(payload) {
       var err = null;
       if (res.httpCode >= 400) {
         err = payload;
         payload = undefined;
       }
-      return callback(err, payload);
+      var json = JSON.parse(payload.toString());
+      return callback(err, json);
     }
   };
   validRoutes[route](req, res, _.omit(newRequest.originalRequest, [ "params", "route" ]));

--- a/lib/router.js
+++ b/lib/router.js
@@ -133,7 +133,7 @@ router.authenticate = function(request, res, callback) {
       detail: err || "You are not authorised to access this resource."
     };
     var payload = responseHelper.generateError(request, errorWrapper);
-    res.status(401).json(payload);
+    res.status(401).end(new Buffer(JSON.stringify(payload)))
   });
 };
 
@@ -187,7 +187,7 @@ router._getParams = function(req) {
 router.sendResponse = function(res, payload, httpCode) {
   var timeDiff = (new Date()) - res._startDate;
   metrics.processResponse(res._request, httpCode, payload, timeDiff);
-  res.status(httpCode).json(payload);
+  res.status(httpCode).end(new Buffer(JSON.stringify(payload)));
 };
 
 router.getExpressServer = function() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-server",
-  "version": "1.15.3",
+  "version": "1.15.4",
   "description": "A config driven NodeJS framework implementing json:api",
   "keywords": [
     "jsonapi",


### PR DESCRIPTION
Express has some interesting behaviour whereby when calling `.send` (or equivalent) with a string, it will override the Content-Type header to append a `charset`:
https://github.com/expressjs/express/issues/2238

This is giving us trouble in our client module whereby `superagent` copies the content-type of the server and replays it back to us. The content type we're currently outputting (`application/vnd.api+json; charset=UTF-8`) isn't one that we accept back - the JSON:API spec specifically states `Servers MUST respond with a 415 Unsupported Media Type status code if a request specifies the header Content-Type: application/vnd.api+json with any media type parameters.`.

This PR changes things so we give express a `Buffer` which bypasses their twiddling of our content-type header.