### PR TITLE
Fix memory handler pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- 2016-08-04 - v1.15.5
+- 2016-08-04 - Fix MemoryHandler pagination
 - 2016-07-06 - v1.15.4
 - 2016-07-06 - Prevent express from appending the charset to the content-type header
 - 2016-07-06 - v1.15.3

--- a/lib/MemoryHandler.js
+++ b/lib/MemoryHandler.js
@@ -34,7 +34,10 @@ MemoryStore.prototype.search = function(request, callback) {
   self._sortList(request, results);
   var resultCount = results.length;
   if (request.params.page) {
-    results = results.slice(request.params.page.offset, request.params.page.offset + request.params.page.limit);
+    var page = request.params.page;
+    var begin = page.offset * page.limit;
+    var end = begin + page.limit;
+    results = results.slice(begin, end);
   }
   return callback(null, MemoryStore._clone(results), resultCount);
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-server",
-  "version": "1.15.4",
+  "version": "1.15.5",
   "description": "A config driven NodeJS framework implementing json:api",
   "keywords": [
     "jsonapi",

--- a/test/pagination.js
+++ b/test/pagination.js
@@ -140,8 +140,9 @@ describe("Testing jsonapi-server", function() {
         assert.equal(json.meta.page.limit, 2, "should have a limit of 2 records");
         assert.equal(json.meta.page.total, 4, "should have a total of 4 records");
 
-        assert.equal(json.data[0].attributes.title, "Linux Rocks", "should be on the third article");
-        assert.equal(json.data[1].attributes.title, "NodeJS Best Practices", "should be on the third article");
+        console.log(json.data);
+        assert.equal(json.data[0].attributes.title, "NodeJS Best Practices", "should be on the third article");
+        assert.equal(json.data[1].attributes.title, "Tea for Beginners", "should be on the fourth article");
 
         assert.ok(Object.keys(json.links).length, 5, "should have 5x links");
         assert.ok(json.links.first.match(/page%5Boffset%5D=0&page%5Blimit%5D=2/), "first should target offset-0 limit-2");


### PR DESCRIPTION
Fix memory handler pagination.

The memory handler wasn't calculating the slice limits correctly, and our test actually tested for the erroneous behaviour: fix the test and correct the calculation of the slice limits.

- [ ]  Me gusta! 👍 