### PR TITLE
allow resourceHandler.initiali'z'e

### DIFF
--- a/lib/jsonApi.js
+++ b/lib/jsonApi.js
@@ -61,6 +61,7 @@ jsonApi.define = function(resourceConfig) {
 
   handlerEnforcer.wrap(resourceConfig.handlers);
 
+  resourceConfig.handlers.initialise = resourceConfig.handlers.initialise || resourceConfig.handlers.initialize;
   if (resourceConfig.handlers.initialise) {
     resourceConfig.handlers.initialise(resourceConfig);
   }


### PR DESCRIPTION
just a quick assignment in case someone uses the 'z' spelling... would have saved me a few minutes today.