### PR TITLE
Throw errors when interpreting invalid relationship schema

### DIFF
--- a/lib/ourJoi.js
+++ b/lib/ourJoi.js
@@ -14,6 +14,7 @@ ourJoi._joiBase = function(resourceName) {
   return relationType;
 };
 Joi.one = function(resource) {
+  if (typeof resource !== "string") throw new Error("Expected a string when defining a primary relation via .one()");
   var obj = Joi.alternatives().try(
     Joi.any().valid(null), // null
     ourJoi._joiBase(resource)
@@ -24,6 +25,7 @@ Joi.one = function(resource) {
   return obj;
 };
 Joi.many = function(resource) {
+  if (typeof resource !== "string") throw new Error("Expected a string when defining a primary relation via .many()");
   var obj = Joi.array().items(ourJoi._joiBase(resource));
   obj._settings = {
     __many: resource


### PR DESCRIPTION
In master right now, if you where to try and incorrectly define a primary relationship in a resources config, for example like this:
```javascript
  author: jsonApi.Joi.one({ type: "people" })
```

Then the server will blow up with an ambigious error like this:
```
/home/dev/repos/jsonapi-server/node_modules/hoek/lib/index.js:731
    throw new Error(msgs.join(' ') || 'Unknown error');
    ^

Error: Value cannot be an object or function
    at Object.exports.assert (/home/dev/repos/jsonapi-server/node_modules/hoek/lib/index.js:731:11)
```

After this PR is merged, you will see a more helpfull error like this:
```
Error: Expected a string when defining a primary relation via .one()
    at Joi.one (/home/dev/repos/jsonapi-server/lib/ourJoi.js:17:43)
    at Object.<anonymous> (/home/dev/repos/jsonapi-server/example/resources/comments.js:17:25)
```