### PR TITLE
ChainHandler improvements

### DIFF
--- a/documentation/chain-handler.md
+++ b/documentation/chain-handler.md
@@ -1,7 +1,7 @@
 
 ### Chaining handlers together with the ChainHandler
 
-This project ships with a handler called the `ChainHandler`. It's purpose is to make it easier to wrap the functionality of one handler with additional functionality. For example using the relational data store may be ideal for storing resources, but what if we want to add an authentication layer on top of those resources? An authentication handler shouldn't know or care about the storage of the underlying resource, it should only deal with authentication - we need an abstraction layer to help us glue all of this together. 
+This project ships with a handler called the `ChainHandler`. It's purpose is to make it easier to wrap the functionality of one handler with additional functionality. For example using the relational data store may be ideal for storing resources, but what if we want to add an authentication layer on top of those resources? An authentication handler shouldn't know or care about the storage of the underlying resource, it should only deal with authentication - we need an abstraction layer to help us glue all of this together.
 
 To get started with the ChainHandler, go ahead and instantiate one:
 ```javascript
@@ -16,10 +16,11 @@ testChainHandler.beforeSearch = function(request, callback) {
   return callback(null, request);
 };
 
-testChainHandler.afterSearch = function(results, pagination, callback) {
+testChainHandler.afterSearch = function(request, results, pagination, callback) {
   return callback(null, results, pagination);
 };
 ```
+*NOTE* The only exception to the above is that all `after` function signatures are also passed the original `request` object in addition to the other objects. This enables us to implement clever features on a per-request basis by providing a mechanism to push state between `before` and `after` functions.
 
 With a new ChainHandler ready to go, this is how we can stack them up:
 ```javascript

--- a/example/handlers/authenticationHandler.js
+++ b/example/handlers/authenticationHandler.js
@@ -7,12 +7,11 @@ authenticationHandler.beforeSearch = function(request, callback) {
   return callback(null, request);
 };
 
-authenticationHandler.afterSearch = function(results, pagination, callback) {
+authenticationHandler.afterSearch = function(request, results, pagination, callback) {
   console.log("After Search 1");
   return callback(null, results, pagination);
 };
 
-authenticationHandler.beforeInitialise = function(resourceConfig, callback) {
-  console.log("Before Initialise 1");
-  return callback(null, resourceConfig);
+authenticationHandler.beforeInitialise = function(resourceConfig) {
+  console.log("Before Initialise 1", resourceConfig.resource);
 };

--- a/example/handlers/timestampHandler.js
+++ b/example/handlers/timestampHandler.js
@@ -7,12 +7,11 @@ timestampHandler.beforeSearch = function(request, callback) {
   return callback(null, request);
 };
 
-timestampHandler.afterSearch = function(results, pagination, callback) {
+timestampHandler.afterSearch = function(request, results, pagination, callback) {
   console.log("After Search 2");
   return callback(null, results, pagination);
 };
 
-timestampHandler.beforeInitialise = function(resourceConfig, callback) {
-  console.log("Before Initialise 2");
-  return callback(null, resourceConfig);
+timestampHandler.beforeInitialise = function(resourceConfig) {
+  console.log("Before Initialise 1", resourceConfig.resource);
 };

--- a/lib/ChainHandler.js
+++ b/lib/ChainHandler.js
@@ -18,13 +18,17 @@ ChainHandler.prototype.chain = function(otherHandler) {
 
 [ 'Initialise', 'Search', 'Find', 'Create', 'Delete', 'Update' ].forEach(function(action) {
   var lowerAction = action.toLowerCase();
-  ChainHandler.prototype[lowerAction] = function() {
+  ChainHandler.prototype[lowerAction] = function(request) {
     var self = this;
     var argsIn = Array.prototype.slice.call(arguments);
     var callback = argsIn.pop();
+    // This block catches invocations to synchronous functions (.initialise())
     if (!(callback instanceof Function)) {
       argsIn.push(callback);
-      callback = function() { };
+      if (self['before' + action]) self['before' + action].apply(self, argsIn);
+      self.otherHandler[lowerAction].apply(self.otherHandler, argsIn);
+      if (self['after' + action]) self['after' + action].apply(self, argsIn);
+      return;
     }
     async.waterfall([
       function(callback) {
@@ -39,7 +43,7 @@ ChainHandler.prototype.chain = function(otherHandler) {
       function() {
         var argsOut = Array.prototype.slice.call(arguments);
         if (!self['after' + action]) return argsOut.pop().apply(self, [null].concat(argsOut));
-        self['after' + action].apply(self, argsOut);
+        self['after' + action].apply(self, [request].concat(argsOut));
       }
     ], callback);
   }


### PR DESCRIPTION
After implementing an `AuthenticationHandler` using the `ChainHandler` I ran in to two issues which I've fixed:

1. There was no way of moving data in scope of a `before` block into an `after` block. I've solved this by making the `request` object available in all `after` blocks. This enables us to implement clever features on a per-request basis by providing a mechanism to push state between `before` and `after` functions.

2. The `.initialise()` function is synchronous, and despite if any before/after blocks immediately invoke their callback's the `waterfall` module deschedules them, causing the functions to fire out of order. I've added a cleaner path through the ChainHandler for synchronous functions to ensure this doesn't happen. This change enables us to use `beforeInitialise` to add attributes to resources before they hit a storage handler, so we can magically add accessTokens to enable authentication checks.