### PR TITLE
Enable dynamic metadata

### DIFF
--- a/documentation/configuring.md
+++ b/documentation/configuring.md
@@ -16,6 +16,10 @@ jsonApi.setConfig({
   meta: {
     copyright: "Blah"
   }
+  // (optional) meta can be a function to be invoked at the end of every request
+  meta: function(request) {
+    return { timestamp: new Date() };
+  }
 });
 ```
 

--- a/lib/responseHelper.js
+++ b/lib/responseHelper.js
@@ -200,7 +200,12 @@ responseHelper._generateResponse = function(request, resourceConfig, sanitisedDa
 };
 
 responseHelper._generateMeta = function(request, handlerTotal) {
-  var meta = _.assign({ }, responseHelper._metadata);
+  var meta;
+  if (typeof responseHelper._metadata === "function") {
+    meta = responseHelper._metadata(request);
+  } else {
+    meta = _.assign({ }, responseHelper._metadata);
+  }
 
   if (handlerTotal) {
     meta.page = pagination.generateMetaSummary(request, handlerTotal);


### PR DESCRIPTION
Resolves #177. `config.meta` now supports both a static object or a function that will be invoked on every request to generated dynamic metadata. The function will be invoked AFTER the handler has finished.

Applying this diff:
```diff
diff --git a/example/server.js b/example/server.js
index b7ddfdc..da76ab7 100644
--- a/example/server.js
+++ b/example/server.js
@@ -25,8 +25,11 @@ jsonApi.setConfig({
   hostname: "localhost",
   port: 16006,
   base: "rest",
-  meta: {
-    description: "This block shows up in the root node of every payload"
+  meta: function(request) {
+    return {
+      description: "This block shows up in the root node of every payload",
+      foo: request.route
+    };
   }
 });
```
Then visiting this URL:
http://localhost:16006/rest/articles
Yields this:
```javascript
meta: {
  description: "This block shows up in the root node of every payload",
  foo: {
    verb: "GET",
    host: "localhost:16006",
    base: "/rest/",
    path: "articles",
    query: "",
    combined: "http://localhost:16006/rest/articles"
  },
  page: {
    offset: 0,
    limit: 50,
    total: 4
  }
}
```