### PR TITLE
Dynamic swagger.json based on handler functionality

### DIFF
--- a/lib/swagger/paths.js
+++ b/lib/swagger/paths.js
@@ -38,85 +38,113 @@ swaggerPaths._addPathDefinition = function(paths, resourceConfig) {
 };
 
 swaggerPaths._addBasicPaths = function(paths, resourceName, resourceConfig) {
-  paths["/" + resourceName] = {
-    get: swaggerPaths._getPathOperationObject({
+  var genericPaths = { };
+  var specificPaths = { };
+  paths["/" + resourceName] = genericPaths;
+  paths["/" + resourceName + "/{id}"] = specificPaths;
+
+  if (resourceConfig.handlers.search) {
+    genericPaths.get = swaggerPaths._getPathOperationObject({
       handler: "search",
       resourceName: resourceName,
       description: "Search for " + resourceName,
       parameters: resourceConfig.searchParams,
       hasPathId: false
-    }),
-    post: swaggerPaths._getPathOperationObject({
+    });
+  }
+
+  if (resourceConfig.handlers.create) {
+    genericPaths.post = swaggerPaths._getPathOperationObject({
       handler: "create",
       resourceName: resourceName,
       description: "Create a new instance of " + resourceName,
       parameters: resourceConfig.attributes,
       hasPathId: false
-    })
-  };
+    });
+  }
 
-  paths["/" + resourceName + "/{id}"] = {
-    get: swaggerPaths._getPathOperationObject({
+  if (resourceConfig.handlers.find) {
+    specificPaths.get = swaggerPaths._getPathOperationObject({
       handler: "find",
       resourceName: resourceName,
       description: "Get a specific instance of " + resourceName,
       hasPathId: true
-    }),
-    delete: swaggerPaths._getPathOperationObject({
-      handler: "delete",
-      resourceName: resourceName,
-      description: "Delete an instance of " + resourceName,
-      hasPathId: true
-    }),
-    patch: swaggerPaths._getPathOperationObject({
+    });
+  }
+
+  if (resourceConfig.handlers.delete) {
+    specificPaths.delete = swaggerPaths._getPathOperationObject({
+        handler: "delete",
+        resourceName: resourceName,
+        description: "Delete an instance of " + resourceName,
+        hasPathId: true
+    });
+  }
+
+  if (resourceConfig.handlers.update) {
+    specificPaths.patch = swaggerPaths._getPathOperationObject({
       handler: "update",
       resourceName: resourceName,
       description: "Update an instance of " + resourceName,
       hasPathId: true
-    })
-  };
+    });
+  }
 };
 
 swaggerPaths._addDeepPaths = function(paths, resourceName, resourceConfig, relationName, relation) {
-  paths["/" + resourceName + "/{id}/" + relationName] = {
-    get: swaggerPaths._getPathOperationObject({
-      handler: "find",
-      resourceName: relation,
-      hasPathId: true
-    })
-  };
+  if (resourceConfig.handlers.find) {
+    paths["/" + resourceName + "/{id}/" + relationName] = {
+      get: swaggerPaths._getPathOperationObject({
+        handler: "find",
+        resourceName: relation,
+        hasPathId: true
+      })
+    };
+  }
 
   var relationType = resourceConfig.attributes[relationName]._settings.__many ? "many" : "one";
-  paths["/" + resourceName + "/{id}/relationships/" + relationName] = {
-    get: swaggerPaths._getPathOperationObject({
+  var relationPaths = { }
+  paths["/" + resourceName + "/{id}/relationships/" + relationName] = relationPaths;
+
+  if (resourceConfig.handlers.find) {
+    relationPaths.get = swaggerPaths._getPathOperationObject({
       handler: "find",
       resourceName: relation,
       relationType: relationType,
       extraTags: resourceName,
       hasPathId: true
-    }),
-    post: swaggerPaths._getPathOperationObject({
+    });
+  }
+
+  if (resourceConfig.handlers.update) {
+    relationPaths.post = swaggerPaths._getPathOperationObject({
       handler: "create",
       resourceName: relation,
       relationType: relationType,
       extraTags: resourceName,
       hasPathId: true
-    }),
-    patch: swaggerPaths._getPathOperationObject({
+    });
+  }
+
+  if (resourceConfig.handlers.update) {
+    relationPaths.patch = swaggerPaths._getPathOperationObject({
       handler: "update",
       resourceName: relation,
       relationType: relationType,
       extraTags: resourceName,
       hasPathId: true
-    }),
-    delete: swaggerPaths._getPathOperationObject({
+    });
+  }
+
+  if (resourceConfig.handlers.update) {
+    relationPaths.delete = swaggerPaths._getPathOperationObject({
       handler: "delete",
       resourceName: relation,
       relationType: relationType,
       extraTags: resourceName,
       hasPathId: true
-    })
-  };
+    });
+  }
 };
 
 swaggerPaths._getPathOperationObject = function(options) {


### PR DESCRIPTION
This resolves #190. The example server uses a handler without a `delete` function. The corresponding swagger.json should accurately reflect this.

Starting the example server and browsing to http://localhost:16006/rest/swagger.json then searching for the `/photos/{id}` path should yield just the `get` and `patch` functionality.

![screen shot 2016-09-19 at 15 08 22](https://cloud.githubusercontent.com/assets/3055120/18635092/a9cd3aee-7e7b-11e6-91bd-681d6f98d5af.png)
