### PR TITLE
Better conversion of Joi types to GraphQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- 2016-09-29 - v2.0.2
+- 2016-09-29 - Better Joi to GraphQL type conversion
 - 2016-09-29 - v2.0.1
 - 2016-09-29 - Adding use-strict to all files
 - 2016-09-29 - v2.0.0

--- a/lib/graphQl/joiConverter.js
+++ b/lib/graphQl/joiConverter.js
@@ -7,7 +7,7 @@ joiConverter.simpleAttribute = joiScheme => {
   let type = joiScheme._type
   if (type === 'any') {
     // { _valids: { _set: [ 'M', 'F' ] } }
-    type = typeof (joiScheme._valids._set || [ ]).pop()
+    type = typeof (joiScheme._valids._set || [ ])[0]
   }
   if (type === 'date') {
     type = 'string'

--- a/lib/graphQl/joiConverter.js
+++ b/lib/graphQl/joiConverter.js
@@ -4,14 +4,23 @@ const graphQl = require('graphql')
 
 joiConverter.simpleAttribute = joiScheme => {
   let type = joiScheme._type
+  if (type === 'any') {
+    // { _valids: { _set: [ 'M', 'F' ] } }
+    type = typeof (joiScheme._valids._set || [ ]).pop()
+  }
   if (type === 'date') {
     type = 'string'
   }
   if (type === 'number') {
     type = 'float'
   }
+
   const uType = type[0].toUpperCase() + type.substring(1)
   type = graphQl[`GraphQL${uType}`]
+
+  if (!type) {
+    throw new Error('Unable to parse Joi type, got ' + JSON.stringify(joiScheme))
+  }
   return type
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-server",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A config driven NodeJS framework implementing json:api",
   "keywords": [
     "jsonapi",


### PR DESCRIPTION
We weren't handling use cases like this:
```
    gender: jsonApi.Joi.any().valid('M', 'F')
      .description('The persons gender, M for Male and F for Female')
      .example('M'),
```
The new behaviour will attempt to guess the type based on the first example. If no type can be identified there will now be a compile-time error.