### PR TITLE
Added array Joi type for GraphQL

### DIFF
--- a/example/resources/photos.js
+++ b/example/resources/photos.js
@@ -24,6 +24,8 @@ jsonApi.define({
       .default(false)
       .description('File in RAW format')
       .example(false),
+    tags: jsonApi.Joi.array().items(jsonApi.Joi.string())
+      .description('Tags for the photo'),
     photographer: jsonApi.Joi.one('people')
       .description('The person who took the photo'),
     articles: jsonApi.Joi.belongsToMany({
@@ -40,6 +42,7 @@ jsonApi.define({
       height: 1080,
       width: 1920,
       raw: true,
+      tags: ['neo', 'morpheus'],
       photographer: { type: 'people', id: 'ad3aa89e-9c5b-4ac9-a652-6670f9f27587' }
     },
     {
@@ -49,6 +52,7 @@ jsonApi.define({
       url: 'http://www.example.com/penguins',
       height: 220,
       width: 60,
+      tags: ['galapagos', 'emperor'],
       photographer: { type: 'people', id: 'd850ea75-4427-4f81-8595-039990aeede5' }
     },
     {
@@ -58,6 +62,7 @@ jsonApi.define({
       url: 'http://www.example.com/treat',
       height: 350,
       width: 350,
+      tags: ['black', 'green'],
       photographer: { type: 'people', id: 'ad3aa89e-9c5b-4ac9-a652-6670f9f27587' }
     }
   ]

--- a/lib/graphQl/joiConverter.js
+++ b/lib/graphQl/joiConverter.js
@@ -16,6 +16,21 @@ joiConverter.simpleAttribute = joiScheme => {
     type = 'float'
   }
 
+  if (type === 'array') {
+      if (joiScheme._inner.items.length === 1) {
+        let joinSubType = joiConverter.simpleAttribute(joiScheme._inner.items[0]);
+
+        if (!joinSubType) {
+          console.log(joiScheme._inner.items[0]);
+          throw new Error('Unable to parse Joi type, got ' + JSON.stringify(joiScheme))
+        }
+
+        return new graphQl.GraphQLList(graphQl.GraphQLString);
+      } else {
+        throw new Error('Joi arrays must contain a single type')
+      }
+  }
+
   const uType = type[0].toUpperCase() + type.substring(1)
   type = graphQl[`GraphQL${uType}`]
 

--- a/lib/graphQl/joiConverter.js
+++ b/lib/graphQl/joiConverter.js
@@ -17,18 +17,18 @@ joiConverter.simpleAttribute = joiScheme => {
   }
 
   if (type === 'array') {
-      if (joiScheme._inner.items.length === 1) {
-        let joinSubType = joiConverter.simpleAttribute(joiScheme._inner.items[0]);
+    if (joiScheme._inner.items.length === 1) {
+      let joinSubType = joiConverter.simpleAttribute(joiScheme._inner.items[0])
 
-        if (!joinSubType) {
-          console.log(joiScheme._inner.items[0]);
-          throw new Error('Unable to parse Joi type, got ' + JSON.stringify(joiScheme))
-        }
-
-        return new graphQl.GraphQLList(graphQl.GraphQLString);
-      } else {
-        throw new Error('Joi arrays must contain a single type')
+      if (!joinSubType) {
+        console.log(joiScheme._inner.items[0])
+        throw new Error('Unable to parse Joi type, got ' + JSON.stringify(joiScheme))
       }
+
+      return new graphQl.GraphQLList(graphQl.GraphQLString)
+    } else {
+      throw new Error('Joi arrays must contain a single type')
+    }
   }
 
   const uType = type[0].toUpperCase() + type.substring(1)

--- a/test/graphQl.js
+++ b/test/graphQl.js
@@ -15,6 +15,7 @@ describe('Testing jsonapi-server graphql', () => {
         photos(width: "<1000") {
           url
           width
+          tags
           photographer(firstname: "Rahul") {
             firstname
           }
@@ -26,11 +27,13 @@ describe('Testing jsonapi-server graphql', () => {
           {
             'url': 'http://www.example.com/penguins',
             'width': 60,
+            'tags': ['galapagos', 'emperor'],
             'photographer': null
           },
           {
             'url': 'http://www.example.com/treat',
             'width': 350,
+            'tags': ['black', 'green'],
             'photographer': {
               'firstname': 'Rahul'
             }

--- a/test/graphQl.js
+++ b/test/graphQl.js
@@ -7,7 +7,6 @@ const client = new Lokka({
   transport: new Transport('http://localhost:16006/rest/')
 })
 
-
 describe('Testing jsonapi-server graphql', () => {
   describe('read operations', () => {
     it('filter with primary join and filter', () => client.query(`


### PR DESCRIPTION
I've added support for arrays with a single scalar type in GraphQL, i.e an array of strings, numbers etc. Although the best practice is to probably have a separate collection sometimes this isn't possible. The spec allows arrays as attributes:

> Complex data structures involving JSON objects and arrays are allowed as attribute values. However, any object that constitutes or is contained in an attribute MUST NOT contain a relationships or links member, as those members are reserved by this specification for future use.

I've also added an embedded tags example to photos and updated the graphql tests :)
