### PR TITLE
Correctly handle validation errors when including non-existing resources

### DIFF
--- a/lib/postProcessing/include.js
+++ b/lib/postProcessing/include.js
@@ -36,6 +36,7 @@ includePP.action = (request, response, callback) => {
 }
 
 includePP._arrayToTree = (request, includes, filters, callback) => {
+  const validationErrors = [ ]
   const tree = {
     _dataItems: null,
     _resourceConfig: request.resourceConfig
@@ -49,7 +50,7 @@ includePP._arrayToTree = (request, includes, filters, callback) => {
 
     let resourceAttribute = node._resourceConfig.attributes[first]
     if (!resourceAttribute) {
-      return callback({
+      return validationErrors.push({
         status: '403',
         code: 'EFORBIDDEN',
         title: 'Invalid inclusion',
@@ -58,7 +59,7 @@ includePP._arrayToTree = (request, includes, filters, callback) => {
     }
     resourceAttribute = resourceAttribute._settings.__one || resourceAttribute._settings.__many
     if (!resourceAttribute) {
-      return callback({
+      return validationErrors.push({
         status: '403',
         code: 'EFORBIDDEN',
         title: 'Invalid inclusion',
@@ -91,6 +92,7 @@ includePP._arrayToTree = (request, includes, filters, callback) => {
     iterate(include, tree, filters)
   })
 
+  if (validationErrors.length > 0) return callback(validationErrors)
   return callback(null, tree)
 }
 

--- a/test/get-resource.js
+++ b/test/get-resource.js
@@ -653,6 +653,22 @@ describe('Testing jsonapi-server', () => {
           done()
         })
       })
+
+      it('should give clean validation errors', done => {
+        const url = 'http://localhost:16006/rest/articles?include=fdfdds,sdf'
+        helpers.request({
+          method: 'GET',
+          url
+        }, (err, res, json) => {
+          assert.equal(err, null)
+          json = helpers.validateError(json)
+
+          assert.equal(res.statusCode, '403', 'Expecting 403 EFORBIDDEN')
+          assert.equal(json.errors.length, 2, 'Should be 2 errors')
+
+          done()
+        })
+      })
     })
   })
 

--- a/test/graphQl.js
+++ b/test/graphQl.js
@@ -7,7 +7,6 @@ const client = new Lokka({
   transport: new Transport('http://localhost:16006/rest/')
 })
 
-
 describe('Testing jsonapi-server graphql', () => {
   describe('read operations', () => {
     it('filter with primary join and filter', () => client.query(`


### PR DESCRIPTION
Fixes #208 - When making a request containing invalid inclusions, we were hitting a callback twice by mistake. Instead of aborting on the first validation error, we now stack them up and fire them all at once.

For example, this request now provides two validation errors and no longer crashes the server:
http://localhost:16006/rest/articles?include=fdfdds,sdf
