### PR TITLE
Polymorphic relationships

### DIFF
--- a/example/handlers/tupleHandler.js
+++ b/example/handlers/tupleHandler.js
@@ -1,0 +1,3 @@
+const jsonApi = require('../..')
+
+module.exports = new jsonApi.MemoryHandler()

--- a/example/resources/tuples.js
+++ b/example/resources/tuples.js
@@ -1,0 +1,34 @@
+const jsonApi = require('../../.')
+const tupleHandler = require('../handlers/tupleHandler.js')
+
+jsonApi.define({
+  namespace: 'json:api',
+  resource: 'tuples',
+  description: 'A demonstration of a polymorphic relationship',
+  handlers: tupleHandler,
+  searchParams: { },
+  attributes: {
+    media: jsonApi.Joi.many('articles', 'photos'),
+    preferred: jsonApi.Joi.one('articles', 'photos')
+  },
+  examples: [
+    {
+      id: 'fbaefe1b-8b80-42c2-b17c-0c397e5b7a0b',
+      type: 'tuples',
+      media: [
+        { type: 'articles', id: 'fa2a073f-8c64-4cbb-9158-b8f67a4ab9f5' },
+        { type: 'photos', id: '72695cbd-e9ef-44f6-85e0-0dbc06a269e8' }
+      ],
+      preferred: { type: 'articles', id: 'fa2a073f-8c64-4cbb-9158-b8f67a4ab9f5' }
+    },
+    {
+      id: '53e4151d-d47d-4188-be22-2b3a290f6690',
+      type: 'tuples',
+      media: [
+        { type: 'articles', id: 'd850ea75-4427-4f81-8595-039990aeede5' },
+        { type: 'photos', id: '4a8acd65-78bb-4020-b9eb-2d058a86a2a0' }
+      ],
+      preferred: { type: 'photos', id: '72695cbd-e9ef-44f6-85e0-0dbc06a269e8' }
+    }
+  ]
+})

--- a/lib/graphQl/joiConverter.js
+++ b/lib/graphQl/joiConverter.js
@@ -21,7 +21,6 @@ joiConverter.simpleAttribute = joiScheme => {
       let joinSubType = joiConverter.simpleAttribute(joiScheme._inner.items[0])
 
       if (!joinSubType) {
-        console.log(joiScheme._inner.items[0])
         throw new Error('Unable to parse Joi type, got ' + JSON.stringify(joiScheme))
       }
 
@@ -45,7 +44,8 @@ joiConverter.swap = (joiScheme, graphQlResources) => {
   if (!joiScheme._settings) {
     type = joiConverter.simpleAttribute(joiScheme)
   } else {
-    const otherType = joiScheme._settings.__one || joiScheme._settings.__many
+    let otherType = joiScheme._settings.__one || joiScheme._settings.__many
+    otherType = otherType.join('_PluS_')
     type = graphQlResources[otherType]
 
     if (joiScheme._settings.__many) {

--- a/lib/graphQl/joiConverter.js
+++ b/lib/graphQl/joiConverter.js
@@ -2,6 +2,7 @@
 const joiConverter = module.exports = { }
 
 const graphQl = require('graphql')
+const readTypes = require('./readTypes.js')
 
 joiConverter.simpleAttribute = joiScheme => {
   let type = joiScheme._type
@@ -45,7 +46,7 @@ joiConverter.swap = (joiScheme, graphQlResources) => {
     type = joiConverter.simpleAttribute(joiScheme)
   } else {
     let otherType = joiScheme._settings.__one || joiScheme._settings.__many
-    otherType = otherType.join('_PluS_')
+    otherType = otherType.join(readTypes.UNION_JOIN_CONST)
     type = graphQlResources[otherType]
 
     if (joiScheme._settings.__many) {

--- a/lib/graphQl/readTypes.js
+++ b/lib/graphQl/readTypes.js
@@ -5,6 +5,8 @@ const graphQl = require('graphql')
 const joiConverter = require('./joiConverter.js')
 const resolvers = require('./resolvers.js')
 const filterArgs = require('./filterArgs.js')
+const UNION_JOIN_CONST = '_PluS_'
+readTypes.UNION_JOIN_CONST = UNION_JOIN_CONST
 
 readTypes.generate = allResourceConfig => {
   const allReadTypes = { }
@@ -56,7 +58,7 @@ readTypes.createReadType = (resourceConfig, otherTypes, allUnionTypes) => {
     if (!joiScheme._settings) return
     const otherResource = joiScheme._settings.__one || joiScheme._settings.__many
     if (otherResource.length <= 1) return
-    const unionType = otherResource.join('_PluS_')
+    const unionType = otherResource.join(UNION_JOIN_CONST)
     if (allUnionTypes.indexOf(unionType) !== -1) return
     allUnionTypes.push(unionType)
   })
@@ -65,12 +67,12 @@ readTypes.createReadType = (resourceConfig, otherTypes, allUnionTypes) => {
 }
 
 readTypes.createUnionType = (unionType, allReadTypes) => {
-  let graphQlTypes = unionType.split('_PluS_').map(a => allReadTypes[a])
+  let graphQlTypes = unionType.split(UNION_JOIN_CONST).map(a => allReadTypes[a])
   return new graphQl.GraphQLUnionType({
     name: unionType,
     types: graphQlTypes,
     resolveType: function (value) {
-      return graphQlTypes[unionType.split('_PluS_').indexOf(value.type)]
+      return graphQlTypes[unionType.split(UNION_JOIN_CONST).indexOf(value.type)]
     }
   })
 }

--- a/lib/graphQl/readTypes.js
+++ b/lib/graphQl/readTypes.js
@@ -8,13 +8,17 @@ const filterArgs = require('./filterArgs.js')
 
 readTypes.generate = allResourceConfig => {
   const allReadTypes = { }
+  const allUnionTypes = [ ]
   Object.keys(allResourceConfig).forEach(resource => {
-    allReadTypes[resource] = readTypes.createReadType(allResourceConfig[resource], allReadTypes)
+    allReadTypes[resource] = readTypes.createReadType(allResourceConfig[resource], allReadTypes, allUnionTypes)
+  })
+  allUnionTypes.forEach(unionType => {
+    allReadTypes[unionType] = readTypes.createUnionType(unionType, allReadTypes)
   })
   return allReadTypes
 }
 
-readTypes.createReadType = (resourceConfig, otherTypes) => {
+readTypes.createReadType = (resourceConfig, otherTypes, allUnionTypes) => {
   const someType = {
     name: resourceConfig.resource,
     description: resourceConfig.description,
@@ -38,12 +42,35 @@ readTypes.createReadType = (resourceConfig, otherTypes) => {
         }
         if (joiScheme._settings) {
           const otherResource = joiScheme._settings.__one || joiScheme._settings.__many
-          fields[attribute].args = filterArgs.generate(otherResource)
+          if (otherResource.length === 1) {
+            fields[attribute].args = filterArgs.generate(otherResource)
+          }
         }
       })
       return fields
     }
   }
 
+  Object.keys(resourceConfig.attributes).forEach(attribute => {
+    const joiScheme = resourceConfig.attributes[attribute]
+    if (!joiScheme._settings) return
+    const otherResource = joiScheme._settings.__one || joiScheme._settings.__many
+    if (otherResource.length <= 1) return
+    const unionType = otherResource.join('_PluS_')
+    if (allUnionTypes.indexOf(unionType) !== -1) return
+    allUnionTypes.push(unionType)
+  })
+
   return new graphQl.GraphQLObjectType(someType)
+}
+
+readTypes.createUnionType = (unionType, allReadTypes) => {
+  let graphQlTypes = unionType.split('_PluS_').map(a => allReadTypes[a])
+  return new graphQl.GraphQLUnionType({
+    name: unionType,
+    types: graphQlTypes,
+    resolveType: function (value) {
+      return graphQlTypes[unionType.split('_PluS_').indexOf(value.type)]
+    }
+  })
 }

--- a/lib/graphQl/resolvers.js
+++ b/lib/graphQl/resolvers.js
@@ -84,7 +84,7 @@ resolvers.generateResourceFromArgs = (args, resourceConfig) => {
         data: args[attribute]
       };
       [].concat(data.relationships[attribute].data).forEach(relation => {
-        relation.type = joiSchema._settings.__one || joiSchema._settings.__many
+        relation.type = (joiSchema._settings.__one || joiSchema._settings.__many)[0]
       })
     }
   })
@@ -95,7 +95,7 @@ resolvers.generateResourceFromArgs = (args, resourceConfig) => {
 resolvers.generateFieldsQueryFromAst = ast => {
   const arrays = (ast.fieldASTs || []).map(fieldAST => fieldAST.selectionSet.selections || [ ])
   const combined = [].concat.apply([], arrays)
-  let fields = combined.map(thing => thing.name.value)
+  let fields = combined.map(thing => (thing.name || { }).value).filter(a => a)
   fields = fields.join(',')
   return fields
 }

--- a/lib/ourJoi.js
+++ b/lib/ourJoi.js
@@ -11,22 +11,27 @@ ourJoi._joiBase = resourceName => {
   })
   return relationType
 }
-Joi.one = resource => {
-  if (typeof resource !== 'string') throw new Error('Expected a string when defining a primary relation via .one()')
-  const obj = Joi.alternatives().try(
-    Joi.any().valid(null), // null
-    ourJoi._joiBase(resource)
-  )
+Joi.one = function () {
+  const resources = Array.prototype.slice.call(arguments)
+  resources.forEach(resource => {
+    if (typeof resource !== 'string') throw new Error('Expected a string when defining a primary relation via .one()')
+  })
+  const obj = Joi.alternatives().try([
+    Joi.any().valid(null) // null
+  ].concat(resources.map(ourJoi._joiBase)))
   obj._settings = {
-    __one: resource
+    __one: resources
   }
   return obj
 }
-Joi.many = resource => {
-  if (typeof resource !== 'string') throw new Error('Expected a string when defining a primary relation via .many()')
-  const obj = Joi.array().items(ourJoi._joiBase(resource))
+Joi.many = function () {
+  const resources = Array.prototype.slice.call(arguments)
+  resources.forEach(resource => {
+    if (typeof resource !== 'string') throw new Error('Expected a string when defining a primary relation via .one()')
+  })
+  const obj = Joi.array().items(resources.map(ourJoi._joiBase))
   obj._settings = {
-    __many: resource
+    __many: resources
   }
   return obj
 }
@@ -41,7 +46,7 @@ Joi.belongsToOne = config => {
     ourJoi._joiBase(config.resource)
   )
   obj._settings = {
-    __one: config.resource,
+    __one: [ config.resource ],
     __as: config.as
   }
   return obj
@@ -50,7 +55,7 @@ Joi.belongsToMany = config => {
   Joi._validateForeignRelation(config)
   const obj = Joi.array().items(ourJoi._joiBase(config.resource))
   obj._settings = {
-    __many: config.resource,
+    __many: [ config.resource ],
     __as: config.as
   }
   return obj

--- a/lib/postProcessing/include.js
+++ b/lib/postProcessing/include.js
@@ -39,7 +39,7 @@ includePP._arrayToTree = (request, includes, filters, callback) => {
   const validationErrors = [ ]
   const tree = {
     _dataItems: null,
-    _resourceConfig: request.resourceConfig
+    _resourceConfig: [ ].concat(request.resourceConfig)
   }
 
   const iterate = (text, node, filter) => {
@@ -48,7 +48,9 @@ includePP._arrayToTree = (request, includes, filters, callback) => {
     const first = parts.shift()
     const rest = parts.join('.')
 
-    let resourceAttribute = node._resourceConfig.attributes[first]
+    let resourceAttribute = node._resourceConfig.map(resourceConfig => {
+      return resourceConfig.attributes[first]
+    }).filter(a => a).pop()
     if (!resourceAttribute) {
       return validationErrors.push({
         status: '403',
@@ -75,7 +77,7 @@ includePP._arrayToTree = (request, includes, filters, callback) => {
     if (!node[first]) {
       node[first] = {
         _dataItems: [ ],
-        _resourceConfig: jsonApi._resources[resourceAttribute],
+        _resourceConfig: resourceAttribute.map(a => jsonApi._resources[a]),
         _filter: [ ]
       }
 

--- a/lib/responseHelper.js
+++ b/lib/responseHelper.js
@@ -127,7 +127,7 @@ responseHelper._generateLink = (item, schemaProperty, linkProperty) => {
   }
 
   if (schemaProperty._settings.__as) {
-    const relatedResource = schemaProperty._settings.__one || schemaProperty._settings.__many
+    const relatedResource = (schemaProperty._settings.__one || schemaProperty._settings.__many)[0]
     // get information about the linkage - list of ids and types
     // /rest/bookings/relationships/?customer=26aa8a92-2845-4e40-999f-1fa006ec8c63
     link.links.self = `${responseHelper._baseUrl + relatedResource}/relationships/?${schemaProperty._settings.__as}=${item.id}`

--- a/lib/routes/related.js
+++ b/lib/routes/related.js
@@ -54,7 +54,9 @@ relatedRoute.register = () => {
         if (relation._settings.__one) {
           relatedResources = relatedResources[0]
         }
-        request.resourceConfig = jsonApi._resources[relation._settings.__one || relation._settings.__many]
+        request.resourceConfig = (relation._settings.__one || relation._settings.__many).map(resourceName => {
+          return jsonApi._resources[resourceName]
+        })
         response = responseHelper._generateResponse(request, resourceConfig, relatedResources)
         if (relatedResources !== null) {
           response.included = [ ]

--- a/lib/routes/removeRelation.js
+++ b/lib/routes/removeRelation.js
@@ -43,7 +43,7 @@ removeRelationRoute.register = () => {
         const keys = [].concat(theirResource[request.params.relation]).map(j => j.id)
 
         for (let i = 0; i < theirs.length; i++) {
-          if (theirs[i].type !== relationType) {
+          if (relationType.indexOf(theirs[i].type) === -1) {
             return callback({
               status: '403',
               code: 'EFORBIDDEN',

--- a/lib/swagger/paths.js
+++ b/lib/swagger/paths.js
@@ -26,11 +26,11 @@ swaggerPaths._addPathDefinition = (paths, resourceConfig) => {
     let relation = resourceConfig.attributes[relationName]
     relation = relation._settings
     if (!relation || relation.__as) return false
-    relation = relation.__many || relation.__one
+    relation = (relation.__many || relation.__one)[0]
     return (jsonApi._resources[relation] && jsonApi._resources[relation].handlers.find)
   }).forEach(relationName => {
     let relation = resourceConfig.attributes[relationName]
-    relation = relation._settings.__one || relation._settings.__many
+    relation = (relation._settings.__one || relation._settings.__many)[0]
 
     swaggerPaths._addDeepPaths(paths, resourceName, resourceConfig, relationName, relation)
   })

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "body-parser": "^1.15.1",
     "cookie-parser": "^1.4.3",
     "debug": "^2.2.0",
+    "eslint-plugin-promise": "^3.3.0",
     "express": "^4.13.4",
     "express-graphql": "^0.5.4",
     "graphql": "^0.7.0",

--- a/test/polymorphicRelationships.js
+++ b/test/polymorphicRelationships.js
@@ -1,0 +1,145 @@
+const assert = require('assert')
+const helpers = require('./helpers.js')
+const jsonApiTestServer = require('../example/server.js')
+
+const Lokka = require('lokka').Lokka
+const Transport = require('lokka-transport-http').Transport
+const client = new Lokka({
+  transport: new Transport('http://localhost:16006/rest/')
+})
+
+describe('Testing jsonapi-server', () => {
+  describe('polymorphic relationships', () => {
+    it('including the tuple', done => {
+      const url = 'http://localhost:16006/rest/tuples?include=media'
+      helpers.request({
+        method: 'GET',
+        url
+      }, (err, res, json) => {
+        assert.equal(err, null)
+        json = helpers.validateJson(json)
+
+        assert.equal(res.statusCode, '200', 'Expecting 200 OK')
+        assert.equal(json.data.length, 2, 'Should be 2 main resources')
+        assert.equal(json.included.length, 4, 'Should be 4 included resources')
+
+        done()
+      })
+    })
+
+    context('including through the tuple', () => {
+      it('including the first half', done => {
+        const url = 'http://localhost:16006/rest/tuples?include=media.photographer'
+        helpers.request({
+          method: 'GET',
+          url
+        }, (err, res, json) => {
+          assert.equal(err, null)
+          json = helpers.validateJson(json)
+
+          assert.equal(res.statusCode, '200', 'Expecting 200 OK')
+          assert.equal(json.included.length, 6, 'Should be no included resources')
+
+          const markExists = json.included.filter(resource => {
+            return resource.attributes.firstname === 'Mark'
+          })
+          assert.ok(markExists, 'Mark should be included as a photographer')
+
+          done()
+        })
+      })
+
+      it('including the second half', done => {
+        const url = 'http://localhost:16006/rest/tuples?include=media.author'
+        helpers.request({
+          method: 'GET',
+          url
+        }, (err, res, json) => {
+          assert.equal(err, null)
+          json = helpers.validateJson(json)
+
+          assert.equal(res.statusCode, '200', 'Expecting 200 OK')
+          assert.equal(json.included.length, 6, 'Should be no included resources')
+
+          const pedroExists = json.included.filter(resource => {
+            return resource.attributes.firstname === 'Pedro'
+          })
+          assert.ok(pedroExists, 'Pedro should be included as an author')
+
+          done()
+        })
+      })
+
+      it('including both', done => {
+        const url = 'http://localhost:16006/rest/tuples?include=media.photographer,media.author'
+        helpers.request({
+          method: 'GET',
+          url
+        }, (err, res, json) => {
+          assert.equal(err, null)
+          json = helpers.validateJson(json)
+
+          assert.equal(res.statusCode, '200', 'Expecting 200 OK')
+          assert.equal(json.included.length, 7, 'Should be no included resources')
+
+          const markExists = json.included.filter(resource => {
+            return resource.attributes.firstname === 'Mark'
+          })
+          assert.ok(markExists, 'Mark should be included as a photographer')
+
+          const pedroExists = json.included.filter(resource => {
+            return resource.attributes.firstname === 'Pedro'
+          })
+          assert.ok(pedroExists, 'Pedro should be included as an author')
+
+          done()
+        })
+      })
+    })
+
+    it('works with GraphQL', () => client.query(`
+      {
+        tuples {
+          preferred {
+            ... on articles {
+              author {
+                firstname
+              }
+            }
+            ... on photos {
+              photographer {
+                firstname
+              }
+            }
+          }
+        }
+      }
+    `).then(result => {
+      assert.deepEqual(result, {
+        'tuples': [
+          {
+            'preferred': {
+              'author': {
+                'firstname': 'Rahul'
+              }
+            }
+          },
+          {
+            'preferred': {
+              'photographer': {
+                'firstname': 'Mark'
+              }
+            }
+          }
+        ]
+      })
+    }))
+  })
+
+  before(() => {
+    jsonApiTestServer.start()
+  })
+  after(() => {
+    jsonApiTestServer.close()
+  })
+})


### PR DESCRIPTION
Resolves #212. This is taking shape, I'm skipping fixing up the swagger doc to support multiple types for now, it'll simply pick the first available type and document that. I'm guessing we can do something with `discrimator` (https://github.com/OAI/OpenAPI-Specification/blob/master/versions/1.2.md#527-model-object) at some point in the future.

Some examples in this action:

```javascript
jsonApi.define({
  resource: 'tuples',
  handlers: tupleHandler,
  attributes: {
    media: jsonApi.Joi.many('articles', 'photos'),
    preferred: jsonApi.Joi.one('articles', 'photos')
  }
})
```

http://localhost:16006/rest/tuples?include=preferred
http://localhost:16006/rest/tuples?include=preferred.author
http://localhost:16006/rest/tuples?include=preferred.photographer
http://localhost:16006/rest/tuples?include=preferred.photographer,preferred.author

```
{
  tuples {
    preferred {
      ... on articles {
        author {
          firstname
        }
      }
      ... on photos {
        photographer {
          firstname
        }
      }
    }
  }
}
====
{
  "data": {
    "tuples": [
      {
        "preferred": {
          "author": {
            "firstname": "Rahul"
          }
        }
      },
      {
        "preferred": {
          "photographer": {
            "firstname": "Mark"
          }
        }
      }
    ]
  }
}
```