### PR TITLE
`jsonApi.close()` does not throw for BYO router

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -95,8 +95,10 @@ router.listen = port => {
 }
 
 router.close = () => {
-  server.close()
-  server = null
+  if (server) {
+    server.close()
+    server = null
+  }
 }
 
 router._routes = { }

--- a/test/close-byo-router.js
+++ b/test/close-byo-router.js
@@ -1,0 +1,48 @@
+const assert = require('assert')
+const childProcess = require('child_process')
+const path = require('path')
+
+describe('Testing jsonapi-server with bring-your-own router', () => {
+  const serverPath = path.join(__dirname, 'fixtures', 'server-byo-router.js')
+
+  let child
+  let isErrorEmitted
+  let isExitEmitted
+  let exitCode
+  let exitSignal
+
+  it('"exit" event, no "error" event', (done) => {
+    setTimeout(() => {
+      assert.equal(isExitEmitted, true)
+      assert.equal(isErrorEmitted, false)
+      done()
+    }, 1000)
+  })
+
+  it('exit code is 0 (success)', () => {
+    assert.equal(exitCode, 0)
+    assert.equal(exitSignal, null)
+  })
+
+  before(() => {
+    child = null
+    isErrorEmitted = false
+    isExitEmitted = false
+    exitCode = null
+
+    child = childProcess.fork(serverPath, [], { stdio: 'inherit' })
+    child.on('error', () => { isErrorEmitted = true })
+    child.on('exit', (code, signal) => {
+      exitCode = code
+      exitSignal = signal
+      isExitEmitted = true
+    })
+  })
+
+  after(() => {
+    if (child) {
+      child.kill()
+      child = null
+    }
+  })
+})

--- a/test/fixtures/server-byo-router.js
+++ b/test/fixtures/server-byo-router.js
@@ -1,0 +1,26 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+
+const express = require('express')
+
+const jsonApi = require('../../.')
+
+const app = express()
+
+jsonApi.setConfig({
+  port: 0,
+  router: app
+})
+
+const resourcesPath = path.join(__dirname, '..', '..', 'example', 'resources')
+fs.readdirSync(resourcesPath).filter(filename => /^[a-z].*\.js$/.test(filename)).map(filename => path.join(resourcesPath, filename)).forEach(require)
+
+jsonApi.start()
+const server = app.listen(0)
+
+setTimeout(() => {
+  jsonApi.close()
+  server.close()
+}, 500)


### PR DESCRIPTION
### Fixed

-   calling `jsonApi.close()` when configured with an existing Express router no longer throws an error (fixes #220)


### Notes

-   I added a test case that configures a JSON API server with an existing Express router, and launches this server in a child process

-   the child process approach seemed to be an easy way to have this additional server run without conflicting with the existing example server