### PR TITLE
add docs and ChainHandler support for handler `close()`

### DIFF
--- a/documentation/handlers.md
+++ b/documentation/handlers.md
@@ -6,6 +6,7 @@ Handlers represent the mechanism that backs a resource. Each handler is an objec
 * a `ready` property indicating the handler is ready to process requests.
 * some of the following methods:
  * `initialise` - when jsonapi-server loads, this is invoked once for every resource using this handler. Its an opportunity to allocate memory, connect to databases, etc.
+ * `close` - for cleaning up upon `jsonApi.close()` (optional)
  * `search` - for searching for resources that match some vague parameters.
  * `find` - for finding a specific resource by id.
  * `create` - for creating a new instance of a resource.
@@ -82,6 +83,10 @@ The `ready` property should be set to a _truthy_ value once the handler is ready
 function(resourceConfig) { };
 ```
 `resourceConfig` is the complete configuration object passed in to `jsonApi.define()`.
+
+#### close
+`close` is invoked without any parameters, when `jsonApi.close()` is called.
+It should close database connections, file handles, timers, event listeners, etc, as though `initialise` were never called.
 
 #### search
 `search` is invoked with a `request` object (see above).

--- a/lib/ChainHandler.js
+++ b/lib/ChainHandler.js
@@ -14,7 +14,7 @@ ChainHandler.prototype.chain = function (otherHandler) {
   return self
 };
 
-[ 'Initialise', 'Search', 'Find', 'Create', 'Delete', 'Update' ].forEach(action => {
+[ 'Initialise', 'Close', 'Search', 'Find', 'Create', 'Delete', 'Update' ].forEach(action => {
   const lowerAction = action.toLowerCase()
   ChainHandler.prototype[lowerAction] = function (request) {
     const self = this
@@ -24,7 +24,10 @@ ChainHandler.prototype.chain = function (otherHandler) {
     if (!(callback instanceof Function)) {
       argsIn.push(callback)
       if (self[`before${action}`]) self[`before${action}`].apply(self, argsIn)
-      self.otherHandler[lowerAction].apply(self.otherHandler, argsIn)
+      if (typeof self.otherHandler[lowerAction] === 'function') {
+        // sync functions like .initialise() and .close() are optional
+        self.otherHandler[lowerAction].apply(self.otherHandler, argsIn)
+      }
       if (self[`after${action}`]) self[`after${action}`].apply(self, argsIn)
       return
     }


### PR DESCRIPTION
### Added

-   document the optional `close()` method that handlers may implement (fixes #221)

-   `ChainHandler` supports the optional handler `close()` method if implemented


### Changed

-   `ChainHandler` supports handlers that do not implement `initialise()`