### PR TITLE
Check resource schema are valid on startup

### DIFF
--- a/lib/jsonApi.js
+++ b/lib/jsonApi.js
@@ -16,6 +16,7 @@ const pagination = require('./pagination.js')
 const routes = require('./routes')
 const url = require('url')
 const metrics = require('./metrics.js')
+const schemaValidator = require('./schemaValidator.js')
 
 jsonApi.Joi = ourJoi.Joi
 jsonApi.metrics = metrics.emitter
@@ -111,6 +112,7 @@ jsonApi.onUncaughtException = errHandler => {
 jsonApi.getExpressServer = () => router.getExpressServer()
 
 jsonApi.start = () => {
+  schemaValidator.validate(jsonApi._resources)
   router.applyMiddleware()
   routes.register()
   if (!jsonApi._apiConfig.router) {

--- a/lib/schemaValidator.js
+++ b/lib/schemaValidator.js
@@ -10,7 +10,7 @@ schemaValidator.validate = function (resources) {
       let types = joiSchema._settings.__one || joiSchema._settings.__many
       types.forEach(type => {
         if (!resources[type]) {
-          throw new Error(`Error: '${resource}'.'${attribute}' is defined to hold a relation with '${type}', but '${type}' is not a valid resource name!`)
+          throw new Error(`'${resource}'.'${attribute}' is defined to hold a relation with '${type}', but '${type}' is not a valid resource name!`)
         }
       })
       let foreignRelation = joiSchema._settings.__as
@@ -18,7 +18,7 @@ schemaValidator.validate = function (resources) {
 
       let backReference = resources[types[0]].attributes[foreignRelation]
       if (!backReference) {
-        throw new Error(`Error: '${resource}'.'${attribute}' is defined as being a foreign relation to the primary '${types[0]}'.'${foreignRelation}', but that primary relationship does not exist!`)
+        throw new Error(`'${resource}'.'${attribute}' is defined as being a foreign relation to the primary '${types[0]}'.'${foreignRelation}', but that primary relationship does not exist!`)
       }
     })
   })

--- a/lib/schemaValidator.js
+++ b/lib/schemaValidator.js
@@ -1,0 +1,25 @@
+'use strict'
+const schemaValidator = module.exports = { }
+
+schemaValidator.validate = function (resources) {
+  Object.keys(resources).forEach(resource => {
+    Object.keys(resources[resource].attributes).forEach(attribute => {
+      let joiSchema = resources[resource].attributes[attribute]
+      if (!joiSchema._settings) return
+
+      let types = joiSchema._settings.__one || joiSchema._settings.__many
+      types.forEach(type => {
+        if (!resources[type]) {
+          throw new Error(`Error: '${resource}'.'${attribute}' is defined to hold a relation with '${type}', but '${type}' is not a valid resource name!`)
+        }
+      })
+      let foreignRelation = joiSchema._settings.__as
+      if (!foreignRelation) return
+
+      let backReference = resources[types[0]].attributes[foreignRelation]
+      if (!backReference) {
+        throw new Error(`Error: '${resource}'.'${attribute}' is defined as being a foreign relation to the primary '${types[0]}'.'${foreignRelation}', but that primary relationship does not exist!`)
+      }
+    })
+  })
+}

--- a/lib/schemaValidator.js
+++ b/lib/schemaValidator.js
@@ -4,19 +4,19 @@ const schemaValidator = module.exports = { }
 schemaValidator.validate = function (resources) {
   Object.keys(resources).forEach(resource => {
     Object.keys(resources[resource].attributes).forEach(attribute => {
-      let joiSchema = resources[resource].attributes[attribute]
+      const joiSchema = resources[resource].attributes[attribute]
       if (!joiSchema._settings) return
 
-      let types = joiSchema._settings.__one || joiSchema._settings.__many
+      const types = joiSchema._settings.__one || joiSchema._settings.__many
       types.forEach(type => {
         if (!resources[type]) {
           throw new Error(`'${resource}'.'${attribute}' is defined to hold a relation with '${type}', but '${type}' is not a valid resource name!`)
         }
       })
-      let foreignRelation = joiSchema._settings.__as
+      const foreignRelation = joiSchema._settings.__as
       if (!foreignRelation) return
 
-      let backReference = resources[types[0]].attributes[foreignRelation]
+      const backReference = resources[types[0]].attributes[foreignRelation]
       if (!backReference) {
         throw new Error(`'${resource}'.'${attribute}' is defined as being a foreign relation to the primary '${types[0]}'.'${foreignRelation}', but that primary relationship does not exist!`)
       }


### PR DESCRIPTION
Resolves #201. Once `myServer.start()` has been invoked, we walk through all the resource definitions ensuring they're all valid.

If a resource has been miss-spelt when defining a relation, you'll get an error like this
```
Error: Resource 'comments' lists attribute 'article' as having a relation with 'article', but 'article' is not a valid resource name!
```

If a foreign relation has been miss-spelt, you'll get an error like this:
```
Error: 'comments'.'article' is defined as being a foreign relation to the primary 'articles'.'comment', but that primary relationship does not exist!
```