### PR TITLE
Multiple filter w/ include fix + internal routing fix + more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules
-coverage.html
+coverage
 complexity
 npm-debug.log
 jsonapi-server.cpuprofile

--- a/example/resources/photos.js
+++ b/example/resources/photos.js
@@ -64,6 +64,18 @@ jsonApi.define({
       width: 350,
       tags: ['black', 'green'],
       photographer: { type: 'people', id: 'ad3aa89e-9c5b-4ac9-a652-6670f9f27587' }
+    },
+    {
+      id: 'ed45eba1-15fe-41c7-93da-1df3dfa5289f',
+      type: 'photos',
+      title: 'Sunset Horizon',
+      url: 'http://www.example.com/sunset',
+      height: 450,
+      width: 1050,
+      raw: true,
+      tags: ['orange', 'sky', 'sun'],
+      photographer: { type: 'people', id: 'cc5cca2e-0dd8-4b95-8cfc-a11230e73116' }
     }
+
   ]
 })

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -67,8 +67,6 @@ filter._parseScalarFilterElement = (attributeConfig, scalarElement) => {
 filter._parseFilterElementHelper = (attributeConfig, filterElement) => {
   if (!filterElement) return { error: 'invalid or empty filter element' }
 
-  if (typeof filterElement === 'string') filterElement = filterElement.split(FILTER_SEPERATOR)
-
   const parsedElements = [].concat(filterElement).map(scalarElement => filter._parseScalarFilterElement(attributeConfig, scalarElement))
 
   if (parsedElements.length === 1) return parsedElements[0]
@@ -116,6 +114,8 @@ filter.parseAndValidate = request => {
 
   for (const key in request.params.filter) {
     filterElement = request.params.filter[key]
+
+    if (typeof filterElement === 'string') request.params.filter[key] = filterElement = filterElement.split(FILTER_SEPERATOR)
 
     if (!Array.isArray(filterElement) && filterElement instanceof Object) continue  // skip deep filters
 

--- a/lib/graphQl/index.js
+++ b/lib/graphQl/index.js
@@ -13,10 +13,12 @@ const writeTypes = require('./writeTypes.js')
 jsonApiGraphQL.with = app => {
   const config = jsonApi._apiConfig
 
-  app.use(new RegExp(`${config.base}$`), graphqlHTTP({
-    schema: jsonApiGraphQL.generate(jsonApi._resources),
-    graphiql: !!config.graphiql
-  }))
+  if (config.graphiql !== false) {
+    app.use(new RegExp(`${config.base}$`), graphqlHTTP({
+      schema: jsonApiGraphQL.generate(jsonApi._resources),
+      graphiql: !!config.graphiql
+    }))
+  }
 }
 
 jsonApiGraphQL.generate = allResourceConfig => {

--- a/lib/graphQl/joiConverter.js
+++ b/lib/graphQl/joiConverter.js
@@ -6,6 +6,7 @@ const readTypes = require('./readTypes.js')
 
 joiConverter.simpleAttribute = joiScheme => {
   let type = joiScheme._type
+
   if (type === 'any') {
     // { _valids: { _set: [ 'M', 'F' ] } }
     type = typeof (joiScheme._valids._set || [ ])[0]
@@ -31,8 +32,23 @@ joiConverter.simpleAttribute = joiScheme => {
     }
   }
 
+  if (type === 'object') {
+    if (joiScheme._inner.children.length) {
+      let joinSubType = joiConverter.simpleAttribute(joiScheme._inner.children[0].schema)
+
+      if (!joinSubType) {
+        throw new Error('Unable to parse Joi type, got ' + JSON.stringify(joiScheme))
+      }
+
+      return new graphQl.GraphQLList(graphQl.GraphQLString)
+    } else {
+      throw new Error('Joi objects must contain defined keys')
+    }
+  }
+
   const uType = type[0].toUpperCase() + type.substring(1)
   type = graphQl[`GraphQL${uType}`]
+
 
   if (!type) {
     throw new Error('Unable to parse Joi type, got ' + JSON.stringify(joiScheme))

--- a/lib/graphQl/joiConverter.js
+++ b/lib/graphQl/joiConverter.js
@@ -6,7 +6,6 @@ const readTypes = require('./readTypes.js')
 
 joiConverter.simpleAttribute = joiScheme => {
   let type = joiScheme._type
-
   if (type === 'any') {
     // { _valids: { _set: [ 'M', 'F' ] } }
     type = typeof (joiScheme._valids._set || [ ])[0]
@@ -32,23 +31,8 @@ joiConverter.simpleAttribute = joiScheme => {
     }
   }
 
-  if (type === 'object') {
-    if (joiScheme._inner.children.length) {
-      let joinSubType = joiConverter.simpleAttribute(joiScheme._inner.children[0].schema)
-
-      if (!joinSubType) {
-        throw new Error('Unable to parse Joi type, got ' + JSON.stringify(joiScheme))
-      }
-
-      return new graphQl.GraphQLList(graphQl.GraphQLString)
-    } else {
-      throw new Error('Joi objects must contain defined keys')
-    }
-  }
-
   const uType = type[0].toUpperCase() + type.substring(1)
   type = graphQl[`GraphQL${uType}`]
-
 
   if (!type) {
     throw new Error('Unable to parse Joi type, got ' + JSON.stringify(joiScheme))

--- a/lib/postProcessing/include.js
+++ b/lib/postProcessing/include.js
@@ -12,7 +12,7 @@ const debug = require('../debugging.js')
 
 includePP.action = (request, response, callback) => {
   let includes = request.params.include
-  const filters = request.params.filter || { }
+  const filters = request.params.filter
   if (!includes) return callback()
   includes = (`${includes}`).split(',')
 
@@ -47,6 +47,7 @@ includePP._arrayToTree = (request, includes, filters, callback) => {
     const parts = text.split('.')
     const first = parts.shift()
     const rest = parts.join('.')
+    if (!filter) filter = {}
 
     let resourceAttribute = node._resourceConfig.map(resourceConfig => {
       return resourceConfig.attributes[first]
@@ -70,6 +71,7 @@ includePP._arrayToTree = (request, includes, filters, callback) => {
     }
 
     filter = filter[first] || { }
+
     if (filter instanceof Array) {
       filter = filter.filter(i => i instanceof Object).pop()
     }

--- a/lib/postProcessing/include.js
+++ b/lib/postProcessing/include.js
@@ -159,7 +159,7 @@ includePP._fillIncludeTree = (includeTree, request, callback) => {
       ids += `&${includeTree[parts[1]]._filter.join('&')}`
     }
     resourcesToFetch.push({
-      url: `${jsonApi._apiConfig.pathPrefix + parts[0]}/?${ids}`,
+      url: `${jsonApi._apiConfig.base + parts[0]}/?${ids}`,
       as: relation
     })
   })
@@ -173,7 +173,7 @@ includePP._fillIncludeTree = (includeTree, request, callback) => {
       ids += `&${includeTree[parts[2]]._filter.join('&')}`
     }
     resourcesToFetch.push({
-      url: `${jsonApi._apiConfig.pathPrefix + parts[1]}/?${ids}`,
+      url: `${jsonApi._apiConfig.base + parts[1]}/?${ids}`,
       as: relation
     })
   })

--- a/lib/rerouter.js
+++ b/lib/rerouter.js
@@ -18,6 +18,7 @@ rerouter.route = (newRequest, callback) => {
 
   const req = {
     url: newRequest.uri,
+    originalUrl: newRequest.originalRequest.originalUrl,
     headers: newRequest.originalRequest.headers,
     cookies: newRequest.originalRequest.cookies,
     params: rerouter._mergeParams(url.parse(newRequest.uri.split('?')[1] || { }), newRequest.params)

--- a/lib/router.js
+++ b/lib/router.js
@@ -184,6 +184,7 @@ router._getParams = req => {
     headers: req.headers,
     safeHeaders: _.omit(req.headers, headersToRemove),
     cookies: req.cookies,
+    originalUrl: req.originalUrl,
     route: {
       verb: req.method,
       host: req.headers.host,

--- a/lib/swagger/index.js
+++ b/lib/swagger/index.js
@@ -17,8 +17,8 @@ swagger._getSwaggerBase = () => {
   let basePath, host, protocol
   if (jsonApi._apiConfig.urlPrefixAlias) {
     const urlObj = url.parse(jsonApi._apiConfig.urlPrefixAlias)
-    basePath = urlObj.pathname.replace(/\/$/, '')
-    if (basePath.length === 0) basePath = '/';
+    basePath = urlObj.pathname
+    if (basePath !== '/') basePath = basePath.replace(/\/$/, '')
     host = urlObj.host
     protocol = urlObj.protocol.replace(/:$/, '')
   } else {
@@ -40,13 +40,6 @@ swagger._getSwaggerBase = () => {
       license: {
         name: (swaggerConfig.license || { }).name,
         url: (swaggerConfig.license || { }).url
-      }
-    },
-    "securityDefinitions": {
-      "api_key": {
-        "type": "apiKey",
-        "name": "api_key",
-        "in": "header"
       }
     },
     host,

--- a/lib/swagger/index.js
+++ b/lib/swagger/index.js
@@ -18,6 +18,7 @@ swagger._getSwaggerBase = () => {
   if (jsonApi._apiConfig.urlPrefixAlias) {
     const urlObj = url.parse(jsonApi._apiConfig.urlPrefixAlias)
     basePath = urlObj.pathname.replace(/\/$/, '')
+    if (basePath.length === 0) basePath = '/';
     host = urlObj.host
     protocol = urlObj.protocol.replace(/:$/, '')
   } else {
@@ -39,6 +40,13 @@ swagger._getSwaggerBase = () => {
       license: {
         name: (swaggerConfig.license || { }).name,
         url: (swaggerConfig.license || { }).url
+      }
+    },
+    "securityDefinitions": {
+      "api_key": {
+        "type": "apiKey",
+        "name": "api_key",
+        "in": "header"
       }
     },
     host,

--- a/lib/swagger/index.js
+++ b/lib/swagger/index.js
@@ -17,7 +17,7 @@ swagger._getSwaggerBase = () => {
   let basePath, host, protocol
   if (jsonApi._apiConfig.urlPrefixAlias) {
     const urlObj = url.parse(jsonApi._apiConfig.urlPrefixAlias)
-    basePath = basePath.replace(/(?!^\/)\/$/, '')
+    basePath = urlObj.pathname.replace(/(?!^\/)\/$/, '')
     host = urlObj.host
     protocol = urlObj.protocol.replace(/:$/, '')
   } else {

--- a/lib/swagger/index.js
+++ b/lib/swagger/index.js
@@ -17,8 +17,7 @@ swagger._getSwaggerBase = () => {
   let basePath, host, protocol
   if (jsonApi._apiConfig.urlPrefixAlias) {
     const urlObj = url.parse(jsonApi._apiConfig.urlPrefixAlias)
-    basePath = urlObj.pathname
-    if (basePath !== '/') basePath = basePath.replace(/\/$/, '')
+    basePath = basePath.replace(/(?!^\/)\//, '')
     host = urlObj.host
     protocol = urlObj.protocol.replace(/:$/, '')
   } else {

--- a/lib/swagger/index.js
+++ b/lib/swagger/index.js
@@ -17,7 +17,7 @@ swagger._getSwaggerBase = () => {
   let basePath, host, protocol
   if (jsonApi._apiConfig.urlPrefixAlias) {
     const urlObj = url.parse(jsonApi._apiConfig.urlPrefixAlias)
-    basePath = basePath.replace(/(?!^\/)\//, '')
+    basePath = basePath.replace(/(?!^\/)\/$/, '')
     host = urlObj.host
     protocol = urlObj.protocol.replace(/:$/, '')
   } else {

--- a/test/_preResourceValidationCheck.js
+++ b/test/_preResourceValidationCheck.js
@@ -6,7 +6,7 @@ describe('Testing jsonapi-server', () => {
   [ { name: 'articles', count: 4 },
     { name: 'comments', count: 3 },
     { name: 'people', count: 4 },
-    { name: 'photos', count: 3 },
+    { name: 'photos', count: 4 },
     { name: 'tags', count: 5 }
   ].forEach(resource => {
     describe(`Searching for ${resource.name}`, () => {

--- a/test/get-resource.js
+++ b/test/get-resource.js
@@ -201,7 +201,7 @@ describe('Testing jsonapi-server', () => {
 
             assert.equal(res.statusCode, '200', 'Expecting 200 OK')
             const photoTypes = json.data.map(i => i.attributes.raw)
-            assert.deepEqual(photoTypes, [ true ], 'expected matching resources')
+            assert.deepEqual(photoTypes, [ true, true ], 'expected matching resources')
 
             done()
           })
@@ -530,13 +530,13 @@ describe('Testing jsonapi-server', () => {
           json = helpers.validateJson(json)
 
           assert.equal(res.statusCode, '200', 'Expecting 200 OK')
-          assert.equal(json.included.length, 7, 'Should be 7 included resources')
+          assert.equal(json.included.length, 8, 'Should be 8 included resources')
 
           const people = json.included.filter(resource => resource.type === 'people')
           assert.equal(people.length, 4, 'Should be 4 included people resources')
 
           const photos = json.included.filter(resource => resource.type === 'photos')
-          assert.equal(photos.length, 3, 'Should be 3 included photos resources')
+          assert.equal(photos.length, 4, 'Should be 4 included photos resources')
 
           done()
         })
@@ -552,13 +552,13 @@ describe('Testing jsonapi-server', () => {
           json = helpers.validateJson(json)
 
           assert.equal(res.statusCode, '200', 'Expecting 200 OK')
-          assert.equal(json.included.length, 7, 'Should be 7 included resources')
+          assert.equal(json.included.length, 8, 'Should be 8 included resources')
 
           const people = json.included.filter(resource => resource.type === 'people')
           assert.equal(people.length, 4, 'Should be 4 included people resources')
 
           const photos = json.included.filter(resource => resource.type === 'photos')
-          assert.equal(photos.length, 3, 'Should be 3 included photos resources')
+          assert.equal(photos.length, 4, 'Should be 4 included photos resources')
 
           done()
         })
@@ -581,6 +581,28 @@ describe('Testing jsonapi-server', () => {
 
           const photos = json.included.filter(resource => resource.type === 'photos')
           assert.equal(photos.length, 1, 'Should be 1 included photos resource')
+
+          done()
+        })
+      })
+
+      it('include author.photos with multiple filters', done => {
+        const url = 'http://localhost:16006/rest/articles?include=author.photos&filter[author][firstname]=Mark,Oli'
+        helpers.request({
+          method: 'GET',
+          url
+        }, (err, res, json) => {
+          assert.equal(err, null)
+          json = helpers.validateJson(json)
+
+          assert.equal(res.statusCode, '200', 'Expecting 200 OK')
+          assert.equal(json.included.length, 4, 'Should be 2 included resources')
+
+          const people = json.included.filter(resource => resource.type === 'people')
+          assert.equal(people.length, 2, 'Should be 2 included people resource')
+
+          const photos = json.included.filter(resource => resource.type === 'photos')
+          assert.equal(photos.length, 2, 'Should be 2 included photos resource')
 
           done()
         })

--- a/test/get-resource.js
+++ b/test/get-resource.js
@@ -587,6 +587,28 @@ describe('Testing jsonapi-server', () => {
       })
 
       it('include author.photos with multiple filters', done => {
+        const url = 'http://localhost:16006/rest/articles?include=author.photos&filter[author]=ad3aa89e-9c5b-4ac9-a652-6670f9f27587&filter[author]=cc5cca2e-0dd8-4b95-8cfc-a11230e73116'
+        helpers.request({
+          method: 'GET',
+          url
+        }, (err, res, json) => {
+          assert.equal(err, null)
+          json = helpers.validateJson(json)
+
+          assert.equal(res.statusCode, '200', 'Expecting 200 OK')
+          assert.equal(json.included.length, 5, 'Should be 2 included resources')
+
+          const people = json.included.filter(resource => resource.type === 'people')
+          assert.equal(people.length, 2, 'Should be 2 included people resource')
+
+          const photos = json.included.filter(resource => resource.type === 'photos')
+          assert.equal(photos.length, 3, 'Should be 2 included photos resource')
+
+          done()
+        })
+      })
+
+      it('include author.photos with multiple filters comma delineated', done => {
         const url = 'http://localhost:16006/rest/articles?include=author.photos&filter[author][firstname]=Mark,Oli'
         helpers.request({
           method: 'GET',

--- a/test/zzPostResourceValidationCheck.js
+++ b/test/zzPostResourceValidationCheck.js
@@ -6,7 +6,7 @@ describe('Testing jsonapi-server', () => {
   [ { name: 'articles', count: 4 },
     { name: 'comments', count: 2 },
     { name: 'people', count: 4 },
-    { name: 'photos', count: 4 },
+    { name: 'photos', count: 5 },
     { name: 'tags', count: 5 }
   ].forEach(resource => {
     describe(`Searching for ${resource.name}`, () => {


### PR DESCRIPTION
Applied a fix that was breaking the ability to acquire includes when using multiple filters through a comma separated list. It seems I was splitting the filter param by comma too far into a particular function that wasn't called when internally routing includes. You'll see the filter split happens immediately in the parseandValidate function. I wrote up two tests for this and added an additional photo resource which required me to modify the counts in a few test assertions.

Additionally in the include lib when building a list of resources to fetch I reduced the url to just the base + path of the url as the hostname is not required while routing internally. This also remedies a problem where the use of pathPrefix which is overwritten by the apiPrefixOverride would cause this route to be incorrect from an internal standpoint.

Finally I appended originalUrl to the request object which persists as the same value during rerouting as it allows me to compare the route object to the originalUrl to see if the request is the result of an include or whatever else may prompt a reroute. I feel like this is a quasi acceptable use of the param as defined in the express API here http://expressjs.com/en/api.html#req.originalUrl