### PR TITLE
start() and close() return promises

### DIFF
--- a/lib/jsonApi.js
+++ b/lib/jsonApi.js
@@ -116,8 +116,10 @@ jsonApi.start = () => {
   router.applyMiddleware()
   routes.register()
   if (!jsonApi._apiConfig.router) {
-    router.listen(jsonApi._apiConfig.port)
+    return router.listen(jsonApi._apiConfig.port)
   }
+  // TODO: no clear way to test if supplied router is listening. Assume it is.
+  return Promise.resolve(true);
 }
 
 jsonApi.close = () => {

--- a/lib/router.js
+++ b/lib/router.js
@@ -90,15 +90,30 @@ router.listen = port => {
     } else {
       server = require('http').createServer(app)
     }
-    server.listen(port)
+    return new Promise((req)=>{
+      server.listen(port, req)
+    });
+  }
+  else {
+    if(server.listening) {
+      return Promise.resolve(true)
+    }
+    else {
+      return new Promise((req)=>{
+        server.on('listening', req)
+      });
+    }
   }
 }
 
 router.close = () => {
   if (server) {
-    server.close()
-    server = null
+    return new Promise((res)=>{
+      server.close(res)
+      server = null
+    });
   }
+  return Promise.resolve(false);
 }
 
 router._routes = { }

--- a/test/test-start-close-promises.js
+++ b/test/test-start-close-promises.js
@@ -1,0 +1,24 @@
+const assert = require('assert')
+const helpers = require('./helpers.js')
+const jsonApiTestServer = require('../example/server.js')
+
+describe('Testing start & close return promises', ()=>{
+  it('start', ()=>{
+    let startPromise = jsonApiTestServer.start();
+    assert.ok(startPromise, "No return value from start.");
+    assert.equal(
+      typeof startPromise.then, "function", "start() returned non-promise.");
+    return startPromise.then(()=>{
+      return jsonApiTestServer.close();
+    });
+  });
+  it('close', ()=>{
+    let startPromise = jsonApiTestServer.start();
+    assert.ok(startPromise, "No return value from start.");
+    assert.equal(
+      typeof startPromise.then, "function", "start() returned non-promise.");
+    return startPromise.then(()=>{
+      return jsonApiTestServer.close();
+    });   
+  });
+});


### PR DESCRIPTION
This is useful (e.g. in testing) when you want to wait to do something once the server is up, or take other cleanup actions once the server is down.