### PR TITLE
Swagger: Quick fix for additional search parameter definitions

### DIFF
--- a/lib/swagger/paths.js
+++ b/lib/swagger/paths.js
@@ -271,6 +271,9 @@ swaggerPaths._getPathOperationObject = options => {
     const additionalParams = Object.keys(options.parameters).map(paramName => {
       const joiScheme = options.parameters[paramName]
       if ((paramName === 'id') || (paramName === 'type')) return null
+      if (((options.handler === 'search') || (options.handler === 'find')) && !options.relation) {
+        if (['sort', 'include', 'filter', 'fields', 'page'].indexOf(paramName) > -1) return null
+      }
 
       return {
         name: paramName,
@@ -279,8 +282,8 @@ swaggerPaths._getPathOperationObject = options => {
         required: ((joiScheme._flags || { }).presence === 'required'),
         type: joiScheme._type
       }
-    })
-    pathDefinition.parameters.concat(additionalParams)
+    }).filter(param => param !== null)
+    pathDefinition.parameters = pathDefinition.parameters.concat(additionalParams)
   }
 
   if (options.relationType) {


### PR DESCRIPTION
Additional parameters were not supported, because `concat` is no inplace operation. The `pathDefinition.parameters` is correctly set now.
For search and find operations, the sort, include, filter, fields, and page query parameters are removed in order to not appear twice.