### PR TITLE
Fix coverage crash & update contributing documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ npm test
 To check the code coverage is still great:
 ```
 npm run coverage
-google-chrome ./coverage.html
+google-chrome ./coverage/lcov-report/index.html
 ```
 
 To see code complexity statistics:

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "scripts": {
     "test": "node ./node_modules/mocha/bin/mocha --require use-strict -S -R spec ./test/*.js",
     "start": "node example/server.js",
-    "coverage": "istanbul cover ./node_modules/mocha/bin/_mocha -- -R spec",
+    "coverage": "istanbul cover ./node_modules/mocha/bin/_mocha -- -S -R spec",
     "complexity": "node ./node_modules/plato/bin/plato -r -d complexity lib",
     "performance": "node --allow-natives-syntax --harmony ./node_modules/mocha/bin/_mocha -S --reporter mocha-performance ./test/*.js",
     "lint": "node ./node_modules/eslint/bin/eslint ./example ./lib ./test --quiet && echo '✔ All good!'",


### PR DESCRIPTION
This fixes a crash when running `npm run coverage`, and also updates the documentation on where to find coverage reports.