### PR TITLE
Update node-inspector to support dev builds on node 7.x and higher

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "lokka-transport-http": "^1.4.0",
     "mocha": "^3.1.0",
     "mocha-performance": "^0.1.1",
-    "node-inspector": "^0.12.8",
+    "node-inspector": "^1.1.0",
     "plato": "^1.7.0",
     "swagger-tools": "^0.10.1",
     "v8-profiler": "^5.6.5"


### PR DESCRIPTION
* New version of node-inspector contains fix for https://github.com/node-inspector/node-inspector/issues/868