### PR TITLE
Throw 403 if a data is not an object

### DIFF
--- a/lib/routes/helper.js
+++ b/lib/routes/helper.js
@@ -34,6 +34,15 @@ helper.checkForBody = (request, callback) => {
       detail: 'Missing "data" - have you sent the right http headers?'
     })
   }
+  // data can be {} or [] both of which are typeof === 'object'
+  if (typeof request.params.data !== 'object') {
+    return callback({
+      status: '403',
+      code: 'EFORBIDDEN',
+      title: 'Request validation failed',
+      detail: '"data" must be an object - have you sent the right http headers?'
+    })
+  }
   callback()
 }
 


### PR DESCRIPTION
* fixes an issue where empty resources were being created when the resource has no required fields and the request json looks like

```javascript
{ "data": "attributes" }
```
