### PR TITLE
Add Node.js v7 as a supported platform and include in CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+sudo: false
 language: node_js
 node_js:
   - 4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
-  - "4"
-  - "6"
+  - 4
+  - 6
+  - 7
 script: "npm run $TEST_STEP"
 env:
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,6 @@ node_js:
   - 4
   - 6
   - 7
-script: "npm run $TEST_STEP"
-env:
-  matrix:
-    - TEST_STEP=jscpd
-    - TEST_STEP=lint
-    - TEST_STEP=test
-    - TEST_STEP=swagger
+script: npm run ci
 notifications:
   email: false

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "performance": "node --allow-natives-syntax --harmony ./node_modules/mocha/bin/_mocha -S --reporter mocha-performance ./test/*.js",
     "lint": "node ./node_modules/eslint/bin/eslint ./example ./lib ./test --quiet && echo '✔ All good!'",
     "jscpd": "jscpd --blame -p ./lib/ || echo 'Finished!'",
-    "swagger": "node ./node_modules/mocha/bin/mocha --require use-strict -S -R spec ./swaggerValidator.js --timeout 60000"
+    "swagger": "node ./node_modules/mocha/bin/mocha --require use-strict -S -R spec ./swaggerValidator.js --timeout 60000",
+    "ci": "npm run jscpd && npm run lint && npm run test && npm run swagger"
   },
   "config": {
     "blanket": {


### PR DESCRIPTION
Some of the projects users are using Node.js v7. Add it as a supported version by including in Travis CI builds.
Also consolidate CI tasks in a single build and update to Trusty containers: this cuts build time for the 3 support node versions from 15 to less than 5 minutes.