### PR TITLE
Fixed GraphQL hard-coded resource name on updates

### DIFF
--- a/lib/graphQl/resolvers.js
+++ b/lib/graphQl/resolvers.js
@@ -30,7 +30,7 @@ resolvers.create = (resourceConfig, parent, args, req, ast) => {
 }
 
 resolvers.update = (resourceConfig, parent, args, req, ast) => {
-  const path = `${jsonApi._apiConfig.pathPrefix + resourceConfig.resource}/${args.tags.id}`
+  const path = `${jsonApi._apiConfig.pathPrefix + resourceConfig.resource}/${args[resourceConfig.resource].id}`
   const data = resolvers.generateResourceFromArgs(args, resourceConfig)
   return resolvers.rerouteTo('PATCH', path, { data }, req, ast)
 }


### PR DESCRIPTION
Fixes #285 

I haven't made any test changes here yet because the only way I see to do that well is with pretty significant test changes. Do you have any thoughts on the best thing to do for tests?