### PR TITLE
add test that shows graphQl varaibles do not work

### DIFF
--- a/test/graphQl.js
+++ b/test/graphQl.js
@@ -41,7 +41,33 @@ describe('Testing jsonapi-server graphql', () => {
       })
     }))
 
-    it('filter with foreign join and filter', () => client.query(`
+    it('filter with foreign join and filter using a GraphQl variable', () => client.query(`
+        query filterWithForeignJoin($name: String!) {
+          people(firstname: $name) {
+            firstname
+            photos(width: "<1000") {
+              url
+              width
+            }
+          }
+        }
+    `, { 'name': 'Rahul' }).then(result => {
+      assert.deepEqual(result, {
+        'people': [
+          {
+            'firstname': 'Rahul',
+            'photos': [
+              {
+                'url': 'http://www.example.com/treat',
+                'width': 350
+              }
+            ]
+          }
+        ]
+      })
+    }))
+
+    it('filter with foreign join and filter with a named query', () => client.query(`
       {
         people(firstname: "Rahul") {
           firstname


### PR DESCRIPTION
Hi,

I created this PR to demonstrate the issue I'm having. 

Currently the GraphQl implementation does not support query variables as far as I can get it to work.

I've added a basic test that uses a named query with a variable passed in a manner which is consistent with the [Lokka](https://github.com/kadirahq/lokka) documentation.

I don't think the GraphQl server parses out the variables properly.

Am I wrong or do you think I might be on to something?

Great work on the server BTW!

Thanks
Laurie

