### PR TITLE
Breaking change: Return error when a response item does not validate.

### DIFF
--- a/example/handlers/brokenResponseHandler.js
+++ b/example/handlers/brokenResponseHandler.js
@@ -1,0 +1,5 @@
+'use strict'
+
+const jsonApi = require('../..')
+
+module.exports = new jsonApi.MemoryHandler()

--- a/example/resources/brokenResponse.js
+++ b/example/resources/brokenResponse.js
@@ -1,0 +1,24 @@
+'use strict'
+
+const jsonApi = require('../../.')
+const brokenResponseHandler = require('../handlers/brokenResponseHandler.js')
+
+jsonApi.define({
+  namespace: 'json:api',
+  resource: 'brokenResponse',
+  description: 'Example demonstrating error handling of broken responses',
+  handlers: brokenResponseHandler,
+  searchParams: { },
+  attributes: {
+    boolean: jsonApi.Joi.boolean(),
+    number: jsonApi.Joi.number()
+  },
+  examples: [
+    {
+      id: 'b3ea78f4-8d03-4708-9945-d58cadc97b04',
+      type: 'brokenResponse',
+      boolean: 1,
+      number: '3'
+    }
+  ]
+})

--- a/lib/responseHelper.js
+++ b/lib/responseHelper.js
@@ -34,7 +34,16 @@ responseHelper._enforceSchemaOnObject = (item, schema, callback) => {
   Joi.validate(item, schema, (err, sanitisedItem) => {
     if (err) {
       debug.validationError(err.message, JSON.stringify(item))
-      return callback(null, null)
+      const res = {
+        status: '500',
+        code: 'EINVALIDITEM',
+        title: 'Item in response does not validate',
+        detail: {
+          item: item,
+          error: err.message
+        }
+      }
+      return callback(res)
     }
 
     const dataItem = responseHelper._generateDataItem(sanitisedItem, schema)

--- a/test/get-resource-id.js
+++ b/test/get-resource-id.js
@@ -20,6 +20,23 @@ describe('Testing jsonapi-server', () => {
       })
     })
 
+    it('broken response should error', done => {
+      const url = 'http://localhost:16006/rest/brokenResponse/b3ea78f4-8d03-4708-9945-d58cadc97b04'
+      helpers.request({
+        method: 'GET',
+        url
+      }, (err, res, json) => {
+        assert.equal(err, null)
+        helpers.validateError(json)
+        const errors = JSON.parse(json).errors
+        assert.equal(res.statusCode, '500', 'Expecting 500')
+        assert.equal(errors.length, 1)
+        assert.equal(errors[0].code, 'EINVALIDITEM')
+        assert.equal(errors[0].detail.error, 'child "boolean" fails because ["boolean" must be a boolean]')
+        done()
+      })
+    })
+
     it('valid lookup', done => {
       const url = 'http://localhost:16006/rest/articles/de305d54-75b4-431b-adb2-eb6b9e546014'
       helpers.request({


### PR DESCRIPTION
Previously, the item would be silently dropped with only a debug message.

This is a breaking change because it changes the behaviour of responses for existing handlers which return an item that does not validate.

Closes #330.