### PR TITLE
Remove node 4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ dist: trusty
 sudo: false
 language: node_js
 node_js:
-  - 4
   - 6
   - 8
 before_install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 - 2017-11-03 - v4.0.0
+- 2017-11-03 - Return error when a response item does not validate.
 - 2017-11-03 - Remove Node.js 4 support.
 - 2017-10-21 - v3.2.2
 - 2017-10-21 - Report coverage with Coveralls.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- 2017-11-03 - v4.0.0
+- 2017-11-03 - Remove Node.js 4 support.
 - 2017-10-21 - v3.2.2
 - 2017-10-21 - Report coverage with Coveralls.
 - 2017-10-21 - Modernise script.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/holidayextras/jsonapi-server"
   },
   "engines": {
-    "node": ">=4.5"
+    "node": ">=6"
   },
   "greenkeeper": {
     "ignore": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-server",
-  "version": "3.2.2",
+  "version": "4.0.0",
   "description": "A config driven NodeJS framework implementing json:api",
   "keywords": [
     "jsonapi",


### PR DESCRIPTION
This PR removes the support of Node 4 in the jsonapi-server. Since Node LTS is now at 8, its time to move on ⏫ 