### PR TITLE
Remove Url.parse limit of parameters (default 1000)

### DIFF
--- a/documentation/configuring.md
+++ b/documentation/configuring.md
@@ -26,7 +26,11 @@ jsonApi.setConfig({
   // (optional) meta can be a function to be invoked at the end of every request
   meta: function(request) {
     return { timestamp: new Date() };
-  }
+  },
+  // (optional) queryStringParsingParameterLimit allows to
+  // override the default limit of 1000 parameters in query string parsing,
+  // documented at : https://github.com/ljharb/qs
+  queryStringParsingParameterLimit: Infinity
 });
 ```
 

--- a/lib/rerouter.js
+++ b/lib/rerouter.js
@@ -15,13 +15,15 @@ rerouter.route = (newRequest, callback) => {
 
   const path = rerouter._generateSanePath(newRequest)
   const route = rerouter._pickFirstMatchingRoute(validRoutes, path)
-
+  const qsOpts = jsonApi._apiConfig.queryStringParsingParameterLimit
+    ? { parameterLimit: jsonApi._apiConfig.queryStringParsingParameterLimit }
+    : { }
   const req = {
     url: newRequest.uri,
     originalUrl: newRequest.originalRequest.originalUrl,
     headers: newRequest.originalRequest.headers,
     cookies: newRequest.originalRequest.cookies,
-    params: rerouter._mergeParams(url.parse(newRequest.uri.split('?')[1] || { }, { parameterLimit: Infinity }), newRequest.params)
+    params: rerouter._mergeParams(url.parse(newRequest.uri.split('?')[1] || { }, qsOpts), newRequest.params)
   }
   rerouter._extendUrlParamsOntoReq(route, path, req)
 

--- a/lib/rerouter.js
+++ b/lib/rerouter.js
@@ -21,7 +21,7 @@ rerouter.route = (newRequest, callback) => {
     originalUrl: newRequest.originalRequest.originalUrl,
     headers: newRequest.originalRequest.headers,
     cookies: newRequest.originalRequest.cookies,
-    params: rerouter._mergeParams(url.parse(newRequest.uri.split('?')[1] || { }), newRequest.params)
+    params: rerouter._mergeParams(url.parse(newRequest.uri.split('?')[1] || { }, { parameterLimit: Infinity }), newRequest.params)
   }
   rerouter._extendUrlParamsOntoReq(route, path, req)
 


### PR DESCRIPTION
When you query more than 1000 items including relationships, you will get only 1000 elements in the `included` array. This is due to the default limit of the `url.parse` method from `qs` (https://github.com/ljharb/qs/blob/master/README.md#parsing-objects)