### PR TITLE
Bug: fix crud operation detection when using chain handlers

### DIFF
--- a/lib/routes/helper.js
+++ b/lib/routes/helper.js
@@ -71,7 +71,13 @@ helper.verifyRequest = (request, resourceConfig, res, handlerRequest, callback) 
     })
   }
 
-  if (!resourceConfig.handlers[handlerRequest]) {
+  // for crud operation support, we need skip over any ChainHandlers to check what the actual store supports
+  let finalHandler = resourceConfig.handlers
+  while (finalHandler.otherHandler) {
+    finalHandler = finalHandler.otherHandler
+  }
+
+  if (!finalHandler[handlerRequest]) {
     return helper.handleError(request, res, {
       status: '403',
       code: 'EFORBIDDEN',


### PR DESCRIPTION
Problem: I ran into an issue where I had a ChainHandler pair with a store that did not support all the crud operations.  I was expecting jsonapi to return a 403 action not supported error, but instead got a 500 when the chainHandler attempted to call the action on the underlying store (which failed with a null ref error).