### PR TITLE
Support filter relationships from sparse fieldsets

### DIFF
--- a/lib/postProcessing/fields.js
+++ b/lib/postProcessing/fields.js
@@ -34,12 +34,25 @@ fields.action = (request, response, callback) => {
     }
   }
 
+  const removeRelationships = jsonApi._apiConfig.removeFilteredRelationships
   allDataItems.forEach(dataItem => {
+    // Removing fields from attributes
     Object.keys(dataItem.attributes).forEach(attribute => {
       if (fields[dataItem.type] && fields[dataItem.type].indexOf(attribute) === -1) {
         delete dataItem.attributes[attribute]
       }
     })
+    // Removing fields from relationships
+    if(!dataItem.relationships instanceof Object || !removeRelationships) return
+    Object.keys(dataItem.relationships).forEach(resource => {
+      if (fields[dataItem.type] && fields[dataItem.type].indexOf(resource) === -1) {
+        delete dataItem.relationships[resource]
+      }
+    })
+    if(!Object.keys(dataItem.relationships).length) {
+      delete dataItem.relationships
+    }
+
   })
 
   return callback()


### PR DESCRIPTION
Should resolve #269.

I'm checking the if the parameter ```removeFilteredRelationships``` from jsonApi config is true to support backward compatibility.

What do you guys think?