### PR TITLE
Fix charset encoding header

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -55,8 +55,12 @@ router.applyMiddleware = () => {
     if (req.headers.accept) {
       // 406 Not Acceptable
       let matchingTypes = req.headers.accept.split(/, ?/)
-      matchingTypes = matchingTypes.filter(mediaType => // Accept application/*, */vnd.api+json, */* and the correct JSON:API type.
-        mediaType.match(/^(\*|application)\/(\*|json|vnd\.api\+json)$/) || mediaType.match(/\*\/\*/))
+      matchingTypes = matchingTypes.filter(mediaType => {
+        // Remove charset encoding
+        const type = mediaType.split(';')[0]
+        // Accept application/*, */vnd.api+json, */* and the correct JSON:API type.
+        return type.match(/^(\*|application)\/(\*|json|vnd\.api\+json)$/) || type.match(/\*\/\*/)
+      })
 
       if (matchingTypes.length === 0) {
         return res.status(406).end()


### PR DESCRIPTION
If the `accept` header has a `charset` added on, which is technically the right way to specify the header according to spec, the current regex does not properly match it. This code splits the encoding to only look at the first part, before the `charset`.