### PR TITLE
Fix autogenerated swagger for array type

### DIFF
--- a/lib/swagger/resources.js
+++ b/lib/swagger/resources.js
@@ -68,6 +68,9 @@ swaggerPaths._getResourceDefinition = resourceConfig => {
         swaggerScheme.type = 'string'
         swaggerScheme.format = 'date'
       }
+      if (swaggerScheme.type === 'array') {
+        swaggerScheme = mapJoiArray(joiScheme, swaggerScheme)
+      }
       attributeShortcut[attribute] = swaggerScheme
 
       if ((joiScheme._flags || { }).presence === 'required') {
@@ -183,3 +186,29 @@ swaggerPaths._getErrorDefinition = () => ({
     }
   }
 })
+function mapJoiArray(joiScheme, swaggerScheme) {
+  const swaggerSchemeResult = Object.assign({}, swaggerScheme)
+  const items = joiScheme._inner.items
+  swaggerSchemeResult.items = { type: 'object' }
+  if (items.length > 0 && items[0]._inner.children) {
+    items[0]._inner.children.forEach(x => {
+      let innerSwaggerSchemeResult = {}
+      const innerJoiScheme = x.schema
+      if (innerJoiScheme._description) {
+        innerSwaggerSchemeResult.description = innerJoiScheme._description
+      }
+      innerSwaggerSchemeResult.type = innerJoiScheme._type
+      if (innerSwaggerSchemeResult.type === 'date') {
+        innerSwaggerSchemeResult.type = 'string'
+        innerSwaggerSchemeResult.format = 'date'
+      }
+      if (innerSwaggerSchemeResult.type === 'array') {
+        innerSwaggerSchemeResult = mapJoiArray(innerJoiScheme, innerSwaggerSchemeResult)
+      }
+      swaggerSchemeResult.items.properties = { ...swaggerSchemeResult.items.properties, [x.key]: innerSwaggerSchemeResult }
+    })
+  } else {
+    swaggerSchemeResult.items = { type: items[0]._type }
+  }
+  return swaggerSchemeResult;
+}

--- a/lib/swagger/resources.js
+++ b/lib/swagger/resources.js
@@ -186,7 +186,7 @@ swaggerPaths._getErrorDefinition = () => ({
     }
   }
 })
-function mapJoiArray(joiScheme, swaggerScheme) {
+function mapJoiArray (joiScheme, swaggerScheme) {
   const swaggerSchemeResult = Object.assign({}, swaggerScheme)
   const items = joiScheme._inner.items
   swaggerSchemeResult.items = { type: 'object' }
@@ -210,5 +210,5 @@ function mapJoiArray(joiScheme, swaggerScheme) {
   } else {
     swaggerSchemeResult.items = { type: items[0]._type }
   }
-  return swaggerSchemeResult;
+  return swaggerSchemeResult
 }


### PR DESCRIPTION
## Problem:
`swagger.json` file is not autogenerated correctly. `items` property is not included when the type is `array`.

![image](https://user-images.githubusercontent.com/58697373/76909308-e4127300-6878-11ea-957b-397f6931992b.png)

## Solution:
Add a recursive function to get nested arrays.

![image](https://user-images.githubusercontent.com/58697373/76908771-816ca780-6877-11ea-996b-3abe85354cd4.png)

